### PR TITLE
update tests/refactoring

### DIFF
--- a/packages/jasmine/describe.model.ts
+++ b/packages/jasmine/describe.model.ts
@@ -1,11 +1,15 @@
-import { CallbackList, Callback } from './jasmine.model';
+import { CallbackList, Callback, DescribeModel } from './jasmine.model';
 
+export interface It {
+    description: string;
+    callback: Callback;
+}
 export interface Describer {
     description: string;
     beforeEachList: CallbackList;
     afterEachList: CallbackList;
     childrenDescribersId: Array<string>;
-    itList: CallbackList;
+    itList: Array<It>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     context: any;
 }
@@ -17,4 +21,28 @@ export interface Describers {
 export interface NextDescriberArguments {
     description: string;
     callback: Callback;
+}
+
+export interface InnerMethods {
+    describe: DescribeModel;
+    addChildDesriberId(describerId: string, childDescriberId: string): void;
+    setFormedDescriber(
+        describer: Describer,
+        describerId: string,
+        isRootDescriber: boolean
+    ): void;
+    performChildrenDescribers(describerId: string): void;
+    initDescribe(description: string, describerId?: string): string;
+    afterCallbackCall(): void;
+    beforeCallbackCall(description: string, describerId: string): void;
+    describeHandler(
+        description: string,
+        callback: Callback,
+        describerId?: string
+    ): void;
+    childDescribe(
+        description: string,
+        callback: Callback,
+        describerId: string
+    ): void;
 }

--- a/packages/jasmine/describe.test.ts
+++ b/packages/jasmine/describe.test.ts
@@ -242,4 +242,20 @@ describe('Describe', () => {
             ]);
         });
     });
+
+    describe('#getMethods', () => {
+        it('should  return describe methods to assigne them to main entry', () => {
+            expect(instance.getMethods()).toEqual({
+                addChildDesriberId: instance.addChildDesriberId,
+                setFormedDescriber: instance.setFormedDescriber,
+                performChildrenDescribers: instance.performChildrenDescribers,
+                initDescribe: instance.initDescribe,
+                afterCallbackCall: instance.afterCallbackCall,
+                beforeCallbackCall: instance.beforeCallbackCall,
+                describeHandler: instance.describeHandler,
+                childDescribe: instance.childDescribe,
+                describe: instance.describe,
+            });
+        });
+    });
 });

--- a/packages/jasmine/describe.ts
+++ b/packages/jasmine/describe.ts
@@ -5,6 +5,7 @@ import {
     Describers,
     NextDescriberArguments,
     Describer,
+    InnerMethods,
 } from './describe.model';
 
 export class Describe implements DescribeCore {
@@ -118,7 +119,7 @@ export class Describe implements DescribeCore {
         ];
     }
 
-    public getMethods(): any {
+    public getMethods(): InnerMethods {
         return {
             addChildDesriberId: this.addChildDesriberId,
             setFormedDescriber: this.setFormedDescriber,

--- a/packages/jasmine/inner-describe.methods.model.ts
+++ b/packages/jasmine/inner-describe.methods.model.ts
@@ -1,0 +1,9 @@
+import { ItModel, BeforeAfterEachModel } from './jasmine.model';
+import { Describer } from './describe.model';
+
+export interface InnerMethods {
+    it: ItModel;
+    beforeEach: BeforeAfterEachModel;
+    afterEach: BeforeAfterEachModel;
+    getActiveDescriber(): Describer;
+}

--- a/packages/jasmine/inner-describe.methods.test.ts
+++ b/packages/jasmine/inner-describe.methods.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-explicit-any */
+
+import { InnerDescribeMethods } from './inner-describe.methods';
+
+describe('InnerDescribeMethods', () => {
+    let instance: any;
+    let callback: any;
+    let describer: any;
+
+    const description = 'description';
+    const activeDescriberId = 'activeDescriberId';
+    const existedBeforeEachCallback = 'existedBeforeEachCallback';
+    const existedAfterEachCallback = 'existedAfterEachCallback';
+    const existedItStructure = 'existedItStructure';
+
+    beforeEach(() => {
+        instance = new InnerDescribeMethods();
+    });
+
+    beforeEach(() => {
+        callback = jest.fn().mockName('callback');
+        describer = {
+            beforeEachList: [existedBeforeEachCallback],
+            afterEachList: [existedAfterEachCallback],
+            itList: [existedItStructure],
+        };
+    });
+
+    describe('#beforeEach', () => {
+        beforeEach(() => {
+            instance.getActiveDescriber = jest
+                .fn()
+                .mockName('getActiveDescriber')
+                .mockReturnValue(describer);
+        });
+
+        it('should add passed beforeEach callback to list of existed to active describer', () => {
+            instance.beforeEach(callback);
+            expect(instance.getActiveDescriber).toHaveBeenCalled();
+            expect(describer.beforeEachList).toEqual([
+                existedBeforeEachCallback,
+                callback,
+            ]);
+        });
+    });
+
+    describe('#afterEach', () => {
+        beforeEach(() => {
+            instance.getActiveDescriber = jest
+                .fn()
+                .mockName('getActiveDescriber')
+                .mockReturnValue(describer);
+        });
+
+        it('should add passed afterEach callback to list of existed to active describer', () => {
+            instance.afterEach(callback);
+            expect(instance.getActiveDescriber).toHaveBeenCalled();
+            expect(describer.afterEachList).toEqual([
+                existedAfterEachCallback,
+                callback,
+            ]);
+        });
+    });
+
+    describe('#it', () => {
+        beforeEach(() => {
+            instance.getActiveDescriber = jest
+                .fn()
+                .mockName('getActiveDescriber')
+                .mockReturnValue(describer);
+        });
+
+        it('should add passed afterEach callback to list of existed to active describer', () => {
+            instance.it(description, callback);
+            expect(instance.getActiveDescriber).toHaveBeenCalled();
+            expect(describer.itList).toEqual([
+                existedItStructure,
+                { description, callback },
+            ]);
+        });
+    });
+
+    describe('#getActiveDescriber', () => {
+        beforeEach(() => {
+            instance.activeDescriberId = activeDescriberId;
+            instance.describers[activeDescriberId] = describer;
+        });
+
+        it('should return active describer', () => {
+            expect(instance.getActiveDescriber()).toBe(describer);
+        });
+    });
+
+    describe('#getMethods', () => {
+        it('should  return innder-describe methods to assigne them to main entry', () => {
+            expect(instance.getMethods()).toEqual({
+                it: instance.it,
+                beforeEach: instance.beforeEach,
+                afterEach: instance.afterEach,
+                getActiveDescriber: instance.getActiveDescriber,
+            });
+        });
+    });
+});

--- a/packages/jasmine/inner-describe.methods.ts
+++ b/packages/jasmine/inner-describe.methods.ts
@@ -1,7 +1,8 @@
-import { BeforeAfterEachCore, Callback } from './jasmine.model';
+import { InnerDescribeMethodsCore, Callback } from './jasmine.model';
 import { Describers, Describer } from './describe.model';
+import { InnerMethods } from './inner-describe.methods.model';
 
-export class BeforeAfterEach implements BeforeAfterEachCore {
+export class InnerDescribeMethods implements InnerDescribeMethodsCore {
     private describers: Describers = {};
     private activeDescriberId: string;
 
@@ -15,13 +16,19 @@ export class BeforeAfterEach implements BeforeAfterEachCore {
         describer.afterEachList = [...describer.afterEachList, callback];
     }
 
+    public it(description: string, callback: Callback): void {
+        const describer = this.getActiveDescriber();
+        describer.itList = [...describer.itList, { description, callback }];
+    }
+
     private getActiveDescriber(): Describer {
         const { activeDescriberId, describers } = this;
         return describers[activeDescriberId];
     }
 
-    public getMethods(): any {
+    public getMethods(): InnerMethods {
         return {
+            it: this.it,
             beforeEach: this.beforeEach,
             afterEach: this.afterEach,
             getActiveDescriber: this.getActiveDescriber,

--- a/packages/jasmine/jasmine.integtaion.test.ts
+++ b/packages/jasmine/jasmine.integtaion.test.ts
@@ -12,24 +12,24 @@ const afeCallbackFirst = () => {};
 const afeCallbackSecond = () => {};
 const afeCallbackThird = () => {};
 
-instance.describe('root_01', () => {
+instance.describe('root-1', () => {
     instance.beforeEach(bfeCallbackFirst);
 
-    instance.describe('child_01_01', () => {
+    instance.describe('child-2', () => {
         instance.afterEach(afeCallbackFirst);
 
-        instance.describe('child_01_01_01', () => {
+        instance.describe('child-3', () => {
             instance.beforeEach(bfeCallbackThird);
             instance.afterEach(afeCallbackSecond);
         });
     });
 
     instance.beforeEach(bfeCallbackSecond);
-    instance.describe('child_01_02', Function);
+    instance.describe('child-4', Function);
 });
 
-instance.describe('root_02', () => {
-    instance.describe('child_02_01', () => {
+instance.describe('root-5', () => {
+    instance.describe('child-6', () => {
         instance.afterEach(afeCallbackThird);
     });
 });
@@ -38,7 +38,7 @@ describe('Integration tests: Describe', () => {
     it('should form valid relationship structure of describers', () => {
         expect(instance.describers).toEqual({
             'root-1': {
-                description: 'root_01',
+                description: 'root-1',
                 beforeEachList: [bfeCallbackFirst, bfeCallbackSecond],
                 afterEachList: [],
                 itList: [],
@@ -46,7 +46,7 @@ describe('Integration tests: Describe', () => {
                 context: {},
             },
             'child-2': {
-                description: 'child_01_01',
+                description: 'child-2',
                 beforeEachList: [],
                 afterEachList: [afeCallbackFirst],
                 itList: [],
@@ -54,7 +54,7 @@ describe('Integration tests: Describe', () => {
                 context: {},
             },
             'child-3': {
-                description: 'child_01_01_01',
+                description: 'child-3',
                 beforeEachList: [bfeCallbackThird],
                 afterEachList: [afeCallbackSecond],
                 itList: [],
@@ -62,7 +62,7 @@ describe('Integration tests: Describe', () => {
                 context: {},
             },
             'child-4': {
-                description: 'child_01_02',
+                description: 'child-4',
                 beforeEachList: [],
                 afterEachList: [],
                 itList: [],
@@ -70,7 +70,7 @@ describe('Integration tests: Describe', () => {
                 context: {},
             },
             'root-5': {
-                description: 'root_02',
+                description: 'root-5',
                 beforeEachList: [],
                 afterEachList: [],
                 itList: [],
@@ -78,7 +78,7 @@ describe('Integration tests: Describe', () => {
                 context: {},
             },
             'child-6': {
-                description: 'child_02_01',
+                description: 'child-6',
                 beforeEachList: [],
                 afterEachList: [afeCallbackThird],
                 itList: [],

--- a/packages/jasmine/jasmine.integtaion.test.ts
+++ b/packages/jasmine/jasmine.integtaion.test.ts
@@ -12,79 +12,112 @@ const afeCallbackFirst = () => {};
 const afeCallbackSecond = () => {};
 const afeCallbackThird = () => {};
 
+const itCallbackFirst = () => {};
+const itCallbackSecond = () => {};
+const itCallbackThird = () => {};
+const itCallbackFourth = () => {};
+const itCallbackFifth = () => {};
+const itCallbackSixth = () => {};
+
 instance.describe('root-1', () => {
     instance.beforeEach(bfeCallbackFirst);
-
+    instance.it('it-1', itCallbackFirst);
     instance.describe('child-2', () => {
         instance.afterEach(afeCallbackFirst);
 
         instance.describe('child-3', () => {
             instance.beforeEach(bfeCallbackThird);
+            instance.it('it-3', itCallbackThird);
             instance.afterEach(afeCallbackSecond);
         });
     });
 
     instance.beforeEach(bfeCallbackSecond);
-    instance.describe('child-4', Function);
+    instance.describe('child-4', () => {
+        instance.it('it-4', itCallbackFourth);
+    });
+
+    instance.it('it-2', itCallbackSecond);
 });
 
 instance.describe('root-5', () => {
     instance.describe('child-6', () => {
         instance.afterEach(afeCallbackThird);
+        instance.it('it-6', itCallbackSixth);
     });
+
+    instance.it('it-5', itCallbackFifth);
 });
 
 describe('Integration tests: Describe', () => {
-    it('should form valid relationship structure of describers', () => {
-        expect(instance.describers).toEqual({
-            'root-1': {
+    describe('should form valid relationship structure of describers for:', () => {
+        it('"root-1": should form valid relationship structure of describers', () => {
+            expect(instance.describers['root-1']).toEqual({
                 description: 'root-1',
                 beforeEachList: [bfeCallbackFirst, bfeCallbackSecond],
                 afterEachList: [],
-                itList: [],
+                itList: [
+                    { description: 'it-1', callback: itCallbackFirst },
+                    { description: 'it-2', callback: itCallbackSecond },
+                ],
                 childrenDescribersId: ['child-2', 'child-4'],
                 context: {},
-            },
-            'child-2': {
+            });
+        });
+
+        it('"root-5": should form valid relationship structure of describers', () => {
+            expect(instance.describers['root-5']).toEqual({
+                description: 'root-5',
+                beforeEachList: [],
+                afterEachList: [],
+                itList: [{ description: 'it-5', callback: itCallbackFifth }],
+                childrenDescribersId: ['child-6'],
+                context: {},
+            });
+        });
+
+        it('"child-2": should form valid relationship structure of describers', () => {
+            expect(instance.describers['child-2']).toEqual({
                 description: 'child-2',
                 beforeEachList: [],
                 afterEachList: [afeCallbackFirst],
                 itList: [],
                 childrenDescribersId: ['child-3'],
                 context: {},
-            },
-            'child-3': {
+            });
+        });
+
+        it('"child-3": should form valid relationship structure of describers', () => {
+            expect(instance.describers['child-3']).toEqual({
                 description: 'child-3',
                 beforeEachList: [bfeCallbackThird],
                 afterEachList: [afeCallbackSecond],
-                itList: [],
+                itList: [{ description: 'it-3', callback: itCallbackThird }],
                 childrenDescribersId: [],
                 context: {},
-            },
-            'child-4': {
+            });
+        });
+
+        it('"child-4": should form valid relationship structure of describers', () => {
+            expect(instance.describers['child-4']).toEqual({
                 description: 'child-4',
                 beforeEachList: [],
                 afterEachList: [],
-                itList: [],
+                itList: [{ description: 'it-4', callback: itCallbackFourth }],
                 childrenDescribersId: [],
                 context: {},
-            },
-            'root-5': {
-                description: 'root-5',
-                beforeEachList: [],
-                afterEachList: [],
-                itList: [],
-                childrenDescribersId: ['child-6'],
-                context: {},
-            },
-            'child-6': {
+            });
+        });
+
+        it('"child-6": should form valid relationship structure of describers', () => {
+            expect(instance.describers['child-6']).toEqual({
                 description: 'child-6',
                 beforeEachList: [],
                 afterEachList: [afeCallbackThird],
-                itList: [],
+                itList: [{ description: 'it-6', callback: itCallbackSixth }],
                 childrenDescribersId: [],
                 context: {},
-            },
+            });
         });
     });
 

--- a/packages/jasmine/jasmine.model.ts
+++ b/packages/jasmine/jasmine.model.ts
@@ -5,21 +5,19 @@ export interface Matchers {
     toBeTruthy(): boolean;
 }
 
-export type DescribeModel = (
-    description: string,
-    callback: Callback,
-    parentDescriberId?: string
-) => void;
+export type DescribeModel = (description: string, callback: Callback) => void;
 export interface DescribeCore {
     describe: DescribeModel;
 }
 
 export type BeforeAfterEachModel = (callback: Callback) => void;
-export interface BeforeAfterEachCore {
+export type ItModel = (description: string, callback: Callback) => void;
+export interface InnerDescribeMethodsCore {
     beforeEach: BeforeAfterEachModel;
     afterEach: BeforeAfterEachModel;
+    it: ItModel;
 }
 
-export type JasmineCore = DescribeCore & BeforeAfterEachCore;
+export type JasmineCore = DescribeCore & InnerDescribeMethodsCore;
 // it(description: string, callback: Callback);
 // expect<EntityToValidate>(entityToValidate: EntityToValidate): Matchers;

--- a/packages/jasmine/jasmine.ts
+++ b/packages/jasmine/jasmine.ts
@@ -2,22 +2,24 @@ import {
     JasmineCore,
     DescribeModel,
     BeforeAfterEachModel,
+    ItModel,
 } from './jasmine.model';
 import { Describe } from './describe';
-import { BeforeAfterEach } from './before-after.each';
+import { InnerDescribeMethods } from './inner-describe.methods';
 
 export class Jasmine implements JasmineCore {
     public describe: DescribeModel;
 
     public beforeEach: BeforeAfterEachModel;
     public afterEach: BeforeAfterEachModel;
+    public it: ItModel;
 
     constructor() {
         const describeInstance = new Describe();
-        const beforeAfterEachInstance = new BeforeAfterEach();
+        const innerDescribeMethodsInstance = new InnerDescribeMethods();
 
-        this.setProperties(describeInstance, beforeAfterEachInstance);
-        this.setMethods(describeInstance, beforeAfterEachInstance);
+        this.setProperties(describeInstance, innerDescribeMethodsInstance);
+        this.setMethods(describeInstance, innerDescribeMethodsInstance);
 
         this.bindPublicApi();
     }
@@ -25,27 +27,28 @@ export class Jasmine implements JasmineCore {
     private bindPublicApi(): void {
         this.afterEach = this.afterEach.bind(this);
         this.beforeEach = this.beforeEach.bind(this);
+        this.it = this.it.bind(this);
+
         this.describe = this.describe.bind(this);
     }
 
     private setMethods(
         describeInstance: Describe,
-        beforeAfterEachInstance: BeforeAfterEach
+        innerDescribeMethodsInstance: InnerDescribeMethods
     ): void {
         Object.assign(
             this,
             describeInstance.getMethods(),
-            beforeAfterEachInstance.getMethods()
+            innerDescribeMethodsInstance.getMethods()
         );
     }
 
     private setProperties(
         describeInstance: Describe,
-        beforeAfterEachInstance: BeforeAfterEach
+        innerDescribeMethodsInstance: InnerDescribeMethods
     ): void {
-        Object.assign(this, describeInstance, beforeAfterEachInstance);
+        Object.assign(this, describeInstance, innerDescribeMethodsInstance);
     }
 
     // expect() {}
-    // it() {}
 }


### PR DESCRIPTION
add missed tests for new implemented inner describe methods (beforeEach/afterEach/it)
add interfaces and tests for new #getMehtods
split validation of describer relationship structure to single test-cases to simplify track their changes
refactor integration tests mock structure to simple define description to inner Ids