### PR TITLE
simplify validators structure/rename wrong method

### DIFF
--- a/packages/jasmine/describe.model.ts
+++ b/packages/jasmine/describe.model.ts
@@ -1,4 +1,4 @@
-import { CallbackList, Callback, DescribeModel } from './jasmine.model';
+import { CallbackList, Callback } from './jasmine.model';
 import { Validator } from './matcher.model';
 
 export interface It {

--- a/packages/jasmine/describe.model.ts
+++ b/packages/jasmine/describe.model.ts
@@ -30,27 +30,3 @@ export interface NextDescriberArguments {
     description: string;
     callback: Callback;
 }
-
-export interface InnerMethods {
-    describe: DescribeModel;
-    addChildDesriberId(describerId: string, childDescriberId: string): void;
-    setFormedDescriber(
-        describer: Describer,
-        describerId: string,
-        isRootDescriber: boolean
-    ): void;
-    performChildrenDescribers(describerId: string): void;
-    initDescribe(description: string, describerId?: string): string;
-    afterCallbackCall(): void;
-    beforeCallbackCall(description: string, describerId: string): void;
-    describeHandler(
-        description: string,
-        callback: Callback,
-        describerId?: string
-    ): void;
-    childDescribe(
-        description: string,
-        callback: Callback,
-        describerId: string
-    ): void;
-}

--- a/packages/jasmine/describe.test.ts
+++ b/packages/jasmine/describe.test.ts
@@ -246,20 +246,4 @@ describe('Describe', () => {
             ]);
         });
     });
-
-    describe('#getMethods', () => {
-        it('should  return describe methods to assigne them to main entry', () => {
-            expect(instance.getMethods()).toEqual({
-                addChildDesriberId: instance.addChildDesriberId,
-                setFormedDescriber: instance.setFormedDescriber,
-                performChildrenDescribers: instance.performChildrenDescribers,
-                initDescribe: instance.initDescribe,
-                afterCallbackCall: instance.afterCallbackCall,
-                beforeCallbackCall: instance.beforeCallbackCall,
-                describeHandler: instance.describeHandler,
-                childDescribe: instance.childDescribe,
-                describe: instance.describe,
-            });
-        });
-    });
 });

--- a/packages/jasmine/describe.test.ts
+++ b/packages/jasmine/describe.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-explicit-any */
 
 import { Describe } from './describe';
+import { store } from './store';
 
 describe('Describe', () => {
     let instance: any;
@@ -12,7 +13,7 @@ describe('Describe', () => {
     const activeDescriberId = 'activeDescriberId';
 
     beforeEach(() => {
-        instance = new Describe();
+        instance = new Describe({ ...store });
     });
 
     beforeEach(() => {
@@ -53,19 +54,22 @@ describe('Describe', () => {
         const isDescriberFormingInProgress = 'isDescriberFormingInProgress';
 
         beforeEach(() => {
-            instance.nextDescriberArguments = [isDescriberFormingInProgress];
+            instance.store.nextDescriberArguments = [
+                isDescriberFormingInProgress,
+            ];
+            instance.store.isDescriberFormingInProgress = false;
             instance.initDescribe = jest.fn();
-            instance.isDescriberFormingInProgress = false;
+
             instance.performChildrenDescribers = jest.fn();
             instance.beforeCallbackCall = jest.fn();
             instance.afterCallbackCall = jest.fn();
         });
 
         it('should store passed description and callback if previous description forming not completed yet', () => {
-            instance.isDescriberFormingInProgress = true;
+            instance.store.isDescriberFormingInProgress = true;
             instance.describeHandler(description, callback);
             expect(instance.initDescribe).not.toHaveBeenCalled();
-            expect(instance.nextDescriberArguments).toEqual([
+            expect(instance.store.nextDescriberArguments).toEqual([
                 isDescriberFormingInProgress,
                 { description, callback },
             ]);
@@ -100,22 +104,22 @@ describe('Describe', () => {
 
         it('should init describer and set its id as active describerId', () => {
             instance.beforeCallbackCall(description, describerId);
-            expect(instance.activeDescriberId).toBe(activeDescriberId);
-            expect(instance.isDescriberFormingInProgress).toBeTruthy();
+            expect(instance.store.activeDescriberId).toBe(activeDescriberId);
+            expect(instance.store.isDescriberFormingInProgress).toBeTruthy();
         });
     });
 
     describe('#afterCallbackCall', () => {
         beforeEach(() => {
             instance.performChildrenDescribers = jest.fn();
-            instance.activeDescriberId = activeDescriberId;
-            instance.isDescriberFormingInProgress = true;
+            instance.store.activeDescriberId = activeDescriberId;
+            instance.store.isDescriberFormingInProgress = true;
         });
 
         it('should clean up acitve describerId and mark forming describer completed', () => {
             instance.afterCallbackCall();
-            expect(instance.activeDescriberId).toBeNull();
-            expect(instance.isDescriberFormingInProgress).toBeFalsy();
+            expect(instance.store.activeDescriberId).toBeNull();
+            expect(instance.store.isDescriberFormingInProgress).toBeFalsy();
         });
 
         it('should perfrom children describers with passed active describerId', () => {
@@ -168,7 +172,7 @@ describe('Describe', () => {
         const parentDescriberId = 'parentDescriberId';
 
         beforeEach(() => {
-            instance.nextDescriberArguments = [{ description, callback }];
+            instance.store.nextDescriberArguments = [{ description, callback }];
             instance.childDescribe = jest.fn();
             instance.addChildDesriberId = jest.fn();
             instance.childDescribe = jest.fn();
@@ -176,7 +180,7 @@ describe('Describe', () => {
 
         it('should clean up next describerArguments', () => {
             instance.performChildrenDescribers(parentDescriberId, describerId);
-            expect(instance.nextDescriberArguments).toEqual([]);
+            expect(instance.store.nextDescriberArguments).toEqual([]);
         });
 
         it('should call #childDescribe for each children', () => {
@@ -202,9 +206,9 @@ describe('Describe', () => {
 
     describe('#setFormedDescriber', () => {
         it('should add describer to collection of existed based on its describerId', () => {
-            instance.describers = { existedDescribers: true };
+            instance.store.describers = { existedDescribers: true };
             instance.setFormedDescriber(describer, describerId, false);
-            expect(instance.describers).toEqual({
+            expect(instance.store.describers).toEqual({
                 existedDescribers: true,
                 [describerId]: describer,
             });
@@ -212,15 +216,15 @@ describe('Describe', () => {
 
         it('should add describer to collection of existed and to list of root desribers if describer is root with generated id', () => {
             const existedRootDescriberId = 'existedRootDescriberId';
-            instance.rootDescribersId = [existedRootDescriberId];
+            instance.store.rootDescribersId = [existedRootDescriberId];
 
             instance.setFormedDescriber(describer, describerId, true);
 
-            expect(instance.rootDescribersId).toEqual([
+            expect(instance.store.rootDescribersId).toEqual([
                 existedRootDescriberId,
                 describerId,
             ]);
-            expect(instance.describers).toEqual({
+            expect(instance.store.describers).toEqual({
                 [describerId]: describer,
             });
         });
@@ -232,7 +236,7 @@ describe('Describe', () => {
             const childDescriberId = 'childDescriberId';
             const describer = { childrenDescribersId: [existedChildId] };
 
-            instance.describers[describerId] = describer;
+            instance.store.describers[describerId] = describer;
 
             instance.addChildDesriberId(describerId, childDescriberId);
 

--- a/packages/jasmine/describe.ts
+++ b/packages/jasmine/describe.ts
@@ -1,11 +1,7 @@
 import uniqueid from 'lodash.uniqueid';
 
 import { Callback, DescribeCore } from './jasmine.model';
-import {
-    NextDescriberArguments,
-    Describer,
-    InnerMethods,
-} from './describe.model';
+import { NextDescriberArguments, Describer } from './describe.model';
 import { Store } from './store';
 
 export class Describe implements DescribeCore {
@@ -121,19 +117,5 @@ export class Describe implements DescribeCore {
             ...describer.childrenDescribersId,
             childDescriberId,
         ];
-    }
-
-    public getMethods(): InnerMethods {
-        return {
-            addChildDesriberId: this.addChildDesriberId,
-            setFormedDescriber: this.setFormedDescriber,
-            performChildrenDescribers: this.performChildrenDescribers,
-            initDescribe: this.initDescribe,
-            afterCallbackCall: this.afterCallbackCall,
-            beforeCallbackCall: this.beforeCallbackCall,
-            describeHandler: this.describeHandler,
-            childDescribe: this.childDescribe,
-            describe: this.describe,
-        };
     }
 }

--- a/packages/jasmine/expect.model.ts
+++ b/packages/jasmine/expect.model.ts
@@ -7,7 +7,7 @@ export interface InnerMethods extends ExpectCore {
         testCase: TestCase,
         expectedResult: ExpectedResult
     ): Validator;
-    getValidators(
+    getMastchers(
         testCase: TestCase,
         expectedResult: ExpectedResult
     ): MatchersCore;

--- a/packages/jasmine/expect.ts
+++ b/packages/jasmine/expect.ts
@@ -1,22 +1,25 @@
 import { Matchers, MatchersTypes } from './matcher';
 
-import { Describers, TestCase } from './describe.model';
+import { TestCase } from './describe.model';
 import { Validator, MatchersCore, ExpectedResult } from './matcher.model';
 import { errorMessages } from './error.messages';
 import { InnerMethods } from './expect.model';
+import { Store } from './store';
 
 export class Expect {
-    private activeDescriberId: string;
-    private activeTestCaseIndex: number;
-    private describers: Describers;
+    constructor(private store: Store) {}
 
-    public expect(expectedResult: ExpectedResult): MatchersCore {
-        const testCase = this.describers[this.activeDescriberId].testCases[
-            this.activeTestCaseIndex
-        ];
+    public expect = (expectedResult: ExpectedResult): MatchersCore => {
+        const {
+            describers,
+            activeDescriberId,
+            activeTestCaseIndex,
+        } = this.store;
+        const testCase =
+            describers[activeDescriberId].testCases[activeTestCaseIndex];
 
         return this.getMastchers(testCase, expectedResult);
-    }
+    };
 
     private getMastchers(
         testCase: TestCase,

--- a/packages/jasmine/expect.ts
+++ b/packages/jasmine/expect.ts
@@ -15,16 +15,16 @@ export class Expect {
             this.activeTestCaseIndex
         ];
 
-        return this.getValidators(testCase, expectedResult);
+        return this.getMastchers(testCase, expectedResult);
     }
 
-    private getValidators(
+    private getMastchers(
         testCase: TestCase,
         expectedResult: ExpectedResult
     ): MatchersCore {
-        const matcher = this.getRegisteredValidator(testCase, expectedResult);
+        const validator = this.getRegisteredValidator(testCase, expectedResult);
 
-        return new Matchers(matcher);
+        return new Matchers(validator);
     }
 
     private getRegisteredValidator(
@@ -33,12 +33,12 @@ export class Expect {
     ): Validator {
         const validator: Validator = {
             expectedResult,
-            validatorCallback: () => ({
+            validatorResult: {
                 isSuccess: false,
                 errorMessage: errorMessages[MatchersTypes.expectDoNothing](
                     expectedResult
                 ),
-            }),
+            },
         };
 
         testCase.validators = [...testCase.validators, validator];
@@ -50,7 +50,7 @@ export class Expect {
         return {
             expect: this.expect,
             getRegisteredValidator: this.getRegisteredValidator,
-            getValidators: this.getValidators,
+            getMastchers: this.getMastchers,
         };
     }
 }

--- a/packages/jasmine/inner-describe.methods.model.ts
+++ b/packages/jasmine/inner-describe.methods.model.ts
@@ -1,9 +1,0 @@
-import { ItModel, BeforeAfterEachModel } from './jasmine.model';
-import { Describer } from './describe.model';
-
-export interface InnerMethods {
-    it: ItModel;
-    beforeEach: BeforeAfterEachModel;
-    afterEach: BeforeAfterEachModel;
-    getActiveDescriber(): Describer;
-}

--- a/packages/jasmine/inner-describe.methods.test.ts
+++ b/packages/jasmine/inner-describe.methods.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-explicit-any */
 
 import { InnerDescribeMethods } from './inner-describe.methods';
+import { store } from './store';
 
 describe('InnerDescribeMethods', () => {
     let instance: any;
@@ -14,7 +15,7 @@ describe('InnerDescribeMethods', () => {
     const existedItStructure = 'existedItStructure';
 
     beforeEach(() => {
-        instance = new InnerDescribeMethods();
+        instance = new InnerDescribeMethods({ ...store });
     });
 
     beforeEach(() => {
@@ -82,8 +83,8 @@ describe('InnerDescribeMethods', () => {
 
     describe('#getActiveDescriber', () => {
         beforeEach(() => {
-            instance.activeDescriberId = activeDescriberId;
-            instance.describers[activeDescriberId] = describer;
+            instance.store.activeDescriberId = activeDescriberId;
+            instance.store.describers[activeDescriberId] = describer;
         });
 
         it('should return active describer', () => {

--- a/packages/jasmine/inner-describe.methods.test.ts
+++ b/packages/jasmine/inner-describe.methods.test.ts
@@ -91,15 +91,4 @@ describe('InnerDescribeMethods', () => {
             expect(instance.getActiveDescriber()).toBe(describer);
         });
     });
-
-    describe('#getMethods', () => {
-        it('should  return innder-describe methods to assigne them to main entry', () => {
-            expect(instance.getMethods()).toEqual({
-                it: instance.it,
-                beforeEach: instance.beforeEach,
-                afterEach: instance.afterEach,
-                getActiveDescriber: instance.getActiveDescriber,
-            });
-        });
-    });
 });

--- a/packages/jasmine/inner-describe.methods.ts
+++ b/packages/jasmine/inner-describe.methods.ts
@@ -1,22 +1,22 @@
 import { InnerDescribeMethodsCore, Callback } from './jasmine.model';
-import { Describers, Describer } from './describe.model';
+import { Describer } from './describe.model';
 import { InnerMethods } from './inner-describe.methods.model';
+import { Store } from './store';
 
 export class InnerDescribeMethods implements InnerDescribeMethodsCore {
-    private describers: Describers = {};
-    private activeDescriberId: string;
+    constructor(private store: Store) {}
 
-    public beforeEach(callback: Callback): void {
+    public beforeEach = (callback: Callback): void => {
         const describer = this.getActiveDescriber();
         describer.beforeEachList = [...describer.beforeEachList, callback];
-    }
+    };
 
-    public afterEach(callback: Callback): void {
+    public afterEach = (callback: Callback): void => {
         const describer = this.getActiveDescriber();
         describer.afterEachList = [...describer.afterEachList, callback];
-    }
+    };
 
-    public it(description: string, callback: Callback): void {
+    public it = (description: string, callback: Callback): void => {
         const describer = this.getActiveDescriber();
         describer.testCases = [
             ...describer.testCases,
@@ -28,10 +28,10 @@ export class InnerDescribeMethods implements InnerDescribeMethodsCore {
                 validators: [],
             },
         ];
-    }
+    };
 
     private getActiveDescriber(): Describer {
-        const { activeDescriberId, describers } = this;
+        const { activeDescriberId, describers } = this.store;
         return describers[activeDescriberId];
     }
 

--- a/packages/jasmine/inner-describe.methods.ts
+++ b/packages/jasmine/inner-describe.methods.ts
@@ -1,6 +1,5 @@
 import { InnerDescribeMethodsCore, Callback } from './jasmine.model';
 import { Describer } from './describe.model';
-import { InnerMethods } from './inner-describe.methods.model';
 import { Store } from './store';
 
 export class InnerDescribeMethods implements InnerDescribeMethodsCore {
@@ -33,14 +32,5 @@ export class InnerDescribeMethods implements InnerDescribeMethodsCore {
     private getActiveDescriber(): Describer {
         const { activeDescriberId, describers } = this.store;
         return describers[activeDescriberId];
-    }
-
-    public getMethods(): InnerMethods {
-        return {
-            it: this.it,
-            beforeEach: this.beforeEach,
-            afterEach: this.afterEach,
-            getActiveDescriber: this.getActiveDescriber,
-        };
     }
 }

--- a/packages/jasmine/jasmine.integtaion.test.ts
+++ b/packages/jasmine/jasmine.integtaion.test.ts
@@ -67,7 +67,7 @@ instance.describe('root-5', () => {
 describe('Integration tests: Describe', () => {
     describe('should form valid relationship structure of describers for:', () => {
         it('"root-1": should form valid relationship structure of describers', () => {
-            expect(instance.describers['root-1']).toEqual({
+            expect(instance.store.describers['root-1']).toEqual({
                 description: 'root-1',
                 beforeEachList: [bfeCallbackFirst, bfeCallbackSecond],
                 afterEachList: [],
@@ -87,7 +87,7 @@ describe('Integration tests: Describe', () => {
         });
 
         it('"root-5": should form valid relationship structure of describers', () => {
-            expect(instance.describers['root-5']).toEqual({
+            expect(instance.store.describers['root-5']).toEqual({
                 description: 'root-5',
                 beforeEachList: [],
                 afterEachList: [],
@@ -103,7 +103,7 @@ describe('Integration tests: Describe', () => {
         });
 
         it('"child-2": should form valid relationship structure of describers', () => {
-            expect(instance.describers['child-2']).toEqual({
+            expect(instance.store.describers['child-2']).toEqual({
                 description: 'child-2',
                 beforeEachList: [],
                 afterEachList: [afeCallbackFirst],
@@ -114,7 +114,7 @@ describe('Integration tests: Describe', () => {
         });
 
         it('"child-3": should form valid relationship structure of describers', () => {
-            expect(instance.describers['child-3']).toEqual({
+            expect(instance.store.describers['child-3']).toEqual({
                 description: 'child-3',
                 beforeEachList: [bfeCallbackThird],
                 afterEachList: [afeCallbackSecond],
@@ -130,7 +130,7 @@ describe('Integration tests: Describe', () => {
         });
 
         it('"child-4": should form valid relationship structure of describers', () => {
-            expect(instance.describers['child-4']).toEqual({
+            expect(instance.store.describers['child-4']).toEqual({
                 description: 'child-4',
                 beforeEachList: [],
                 afterEachList: [],
@@ -146,7 +146,7 @@ describe('Integration tests: Describe', () => {
         });
 
         it('"child-6": should form valid relationship structure of describers', () => {
-            expect(instance.describers['child-6']).toEqual({
+            expect(instance.store.describers['child-6']).toEqual({
                 description: 'child-6',
                 beforeEachList: [],
                 afterEachList: [afeCallbackThird],
@@ -163,23 +163,28 @@ describe('Integration tests: Describe', () => {
     });
 
     it('should collect root describers id in separate list', () => {
-        expect(instance.rootDescribersId).toEqual(['root-1', 'root-5']);
+        expect(instance.store.rootDescribersId).toEqual(['root-1', 'root-5']);
     });
 
     it('should link children describers in parent', () => {
-        expect(instance.describers['root-1'].childrenDescribersId).toEqual([
-            'child-2',
-            'child-4',
-        ]);
-        expect(instance.describers['root-5'].childrenDescribersId).toEqual([
-            'child-6',
-        ]);
-        expect(instance.describers['child-2'].childrenDescribersId).toEqual([
-            'child-3',
-        ]);
-        expect(instance.describers['child-3'].childrenDescribersId).toEqual([]);
-        expect(instance.describers['child-4'].childrenDescribersId).toEqual([]);
-        expect(instance.describers['child-6'].childrenDescribersId).toEqual([]);
+        expect(
+            instance.store.describers['root-1'].childrenDescribersId
+        ).toEqual(['child-2', 'child-4']);
+        expect(
+            instance.store.describers['root-5'].childrenDescribersId
+        ).toEqual(['child-6']);
+        expect(
+            instance.store.describers['child-2'].childrenDescribersId
+        ).toEqual(['child-3']);
+        expect(
+            instance.store.describers['child-3'].childrenDescribersId
+        ).toEqual([]);
+        expect(
+            instance.store.describers['child-4'].childrenDescribersId
+        ).toEqual([]);
+        expect(
+            instance.store.describers['child-6'].childrenDescribersId
+        ).toEqual([]);
     });
 });
 

--- a/packages/jasmine/jasmine.ts
+++ b/packages/jasmine/jasmine.ts
@@ -11,8 +11,18 @@ import { Describe } from './describe';
 import { InnerDescribeMethods } from './inner-describe.methods';
 import { Expect } from './expect';
 import { Runner } from './runner';
+import { Store } from './store';
 
 export class Jasmine implements JasmineCore {
+    private store: Store = {
+        activeDescriberId: null,
+        isDescriberFormingInProgress: false,
+        describers: {},
+        rootDescribersId: [],
+        activeTestCaseIndex: null,
+        nextDescriberArguments: [],
+    };
+
     public describe: DescribeModel;
 
     public beforeEach: BeforeAfterEachModel;
@@ -25,68 +35,28 @@ export class Jasmine implements JasmineCore {
     public run: RunModel;
 
     constructor() {
-        const describeInstance = new Describe();
-        const innerDescribeMethodsInstance = new InnerDescribeMethods();
-        const expectInstance = new Expect();
-        const runnerInstance = new Runner();
-
-        this.setProperties(
-            describeInstance,
-            innerDescribeMethodsInstance,
-            expectInstance,
-            runnerInstance
+        this.setPublicApi(
+            new Describe(this.store),
+            new InnerDescribeMethods(this.store),
+            new Expect(this.store),
+            new Runner(this.store)
         );
-        this.setMethods(
-            describeInstance,
-            innerDescribeMethodsInstance,
-            expectInstance,
-            runnerInstance
-        );
-
-        this.bindPublicApi();
     }
 
-    private bindPublicApi(): void {
-        this.afterEach = this.afterEach.bind(this);
-        this.beforeEach = this.beforeEach.bind(this);
-
-        this.it = this.it.bind(this);
-        this.expect = this.expect.bind(this);
-
-        this.describe = this.describe.bind(this);
-
-        this.run = this.run.bind(this);
-    }
-
-    private setMethods(
+    private setPublicApi(
         describeInstance: Describe,
         innerDescribeMethodsInstance: InnerDescribeMethods,
         expectInstance: Expect,
         runnerInstance: Runner
     ): void {
-        Object.assign(
-            this,
-            describeInstance.getMethods(),
-            innerDescribeMethodsInstance.getMethods(),
-            expectInstance.getMethods(),
-            runnerInstance.getMethods()
-        );
-    }
+        this.describe = describeInstance.describe;
 
-    private setProperties(
-        describeInstance: Describe,
-        innerDescribeMethodsInstance: InnerDescribeMethods,
-        expectInstance: Expect,
-        runnerInstance: Runner
-    ): void {
-        Object.assign(
-            this,
-            describeInstance,
-            innerDescribeMethodsInstance,
-            expectInstance,
-            runnerInstance
-        );
-    }
+        this.afterEach = innerDescribeMethodsInstance.afterEach;
+        this.beforeEach = innerDescribeMethodsInstance.beforeEach;
 
-    // expect() {}
+        this.it = innerDescribeMethodsInstance.it;
+        this.expect = expectInstance.expect;
+
+        this.run = runnerInstance.run;
+    }
 }

--- a/packages/jasmine/jasmine.ts
+++ b/packages/jasmine/jasmine.ts
@@ -11,15 +11,13 @@ import { Describe } from './describe';
 import { InnerDescribeMethods } from './inner-describe.methods';
 import { Expect } from './expect';
 import { Runner } from './runner';
-import { Store } from './store';
+import { Store, store } from './store';
 
 export class Jasmine implements JasmineCore {
     private store: Store = {
-        activeDescriberId: null,
-        isDescriberFormingInProgress: false,
+        ...store,
         describers: {},
         rootDescribersId: [],
-        activeTestCaseIndex: null,
         nextDescriberArguments: [],
     };
 

--- a/packages/jasmine/matcher.model.ts
+++ b/packages/jasmine/matcher.model.ts
@@ -12,7 +12,7 @@ export type ValidatorCallback = () => ValidatorResult;
 
 export interface Validator {
     expectedResult: ExpectedResult;
-    validatorCallback: ValidatorCallback;
+    validatorResult: ValidatorResult;
 }
 
 export interface MatchersCore {

--- a/packages/jasmine/matcher.ts
+++ b/packages/jasmine/matcher.ts
@@ -75,6 +75,6 @@ export class Matchers implements MatchersCore {
 
     private setValidatorCallback(validatorCallback: ValidatorCallback): void {
         const { validator } = this;
-        validator.validatorCallback = validatorCallback;
+        validator.validatorResult = validatorCallback();
     }
 }

--- a/packages/jasmine/runner.model.ts
+++ b/packages/jasmine/runner.model.ts
@@ -1,4 +1,4 @@
-import { Validator, ValidatorResult, ValidatorResults } from './matcher.model';
+import { ValidatorResults } from './matcher.model';
 import { TestCase, Context } from './describe.model';
 
 export interface TestCaseResult {
@@ -14,7 +14,6 @@ export type TestsResults = Array<TestResults>;
 export interface InnerMethods {
     setActiveTestCaseIndex(index: number): void;
     setActiveDescriberId(describerId: string): void;
-    getValidatorResult({ validatorCallback }: Validator): ValidatorResult;
     performTestAndReturnItsResult(
         context: Context,
         { it, validators }: TestCase,

--- a/packages/jasmine/runner.model.ts
+++ b/packages/jasmine/runner.model.ts
@@ -5,6 +5,8 @@ export interface TestCaseResult {
     itDescription: string;
     validatorResults: ValidatorResults;
 }
+export type TestCaseResults = Array<TestCaseResult>;
+
 export interface TestResults {
     description: string;
     testCaseResults: Array<TestCaseResult>;

--- a/packages/jasmine/runner.model.ts
+++ b/packages/jasmine/runner.model.ts
@@ -1,5 +1,4 @@
 import { ValidatorResults } from './matcher.model';
-import { TestCase, Context } from './describe.model';
 
 export interface TestCaseResult {
     itDescription: string;
@@ -12,22 +11,3 @@ export interface TestResults {
     testCaseResults: Array<TestCaseResult>;
 }
 export type TestsResults = Array<TestResults>;
-
-export interface InnerMethods {
-    setActiveTestCaseIndex(index: number): void;
-    setActiveDescriberId(describerId: string): void;
-    performTestAndReturnItsResult(
-        context: Context,
-        { it, validators }: TestCase,
-        index: number
-    ): TestCaseResult;
-    performTestsAndReturnTheirResults(
-        testsResults: TestsResults,
-        describerId: string
-    ): TestsResults;
-    performDecribers(
-        describersIds: Array<string>,
-        testsResults: TestsResults
-    ): TestsResults;
-    run(): TestsResults;
-}

--- a/packages/jasmine/runner.ts
+++ b/packages/jasmine/runner.ts
@@ -1,4 +1,4 @@
-import { ValidatorResult, Validator } from './matcher.model';
+import { Validator } from './matcher.model';
 import { Describer, TestCase, Context } from './describe.model';
 import { Callback } from './jasmine.model';
 import { InnerMethods, TestsResults, TestCaseResult } from './runner.model';
@@ -67,14 +67,10 @@ export class Runner {
 
         return {
             itDescription: it.description,
-            validatorResults: testCase.validators.map(this.getValidatorResult),
+            validatorResults: testCase.validators.map(
+                ({ validatorResult }: Validator) => validatorResult
+            ),
         };
-    }
-
-    private getValidatorResult({
-        validatorCallback,
-    }: Validator): ValidatorResult {
-        return validatorCallback();
     }
 
     private setActiveDescriberId(describerId: string): void {
@@ -89,7 +85,6 @@ export class Runner {
         return {
             setActiveTestCaseIndex: this.setActiveTestCaseIndex,
             setActiveDescriberId: this.setActiveDescriberId,
-            getValidatorResult: this.getValidatorResult,
             performTestAndReturnItsResult: this.performTestAndReturnItsResult,
             performTestsAndReturnTheirResults: this
                 .performTestsAndReturnTheirResults,

--- a/packages/jasmine/runner.ts
+++ b/packages/jasmine/runner.ts
@@ -1,12 +1,7 @@
 import { Validator } from './matcher.model';
 import { TestCase, Context } from './describe.model';
 import { Callback } from './jasmine.model';
-import {
-    InnerMethods,
-    TestsResults,
-    TestCaseResult,
-    TestCaseResults,
-} from './runner.model';
+import { TestsResults, TestCaseResult, TestCaseResults } from './runner.model';
 import { Store } from './store';
 
 export class Runner {
@@ -82,17 +77,5 @@ export class Runner {
 
     private setActiveTestCaseIndex(index: number): void {
         this.store.activeTestCaseIndex = index;
-    }
-
-    public getMethods(): InnerMethods {
-        return {
-            setActiveTestCaseIndex: this.setActiveTestCaseIndex,
-            setActiveDescriberId: this.setActiveDescriberId,
-            performTestAndReturnItsResult: this.performTestAndReturnItsResult,
-            performTestsAndReturnTheirResults: this
-                .performTestsAndReturnTheirResults,
-            performDecribers: this.performDecribers,
-            run: this.run,
-        };
     }
 }

--- a/packages/jasmine/runner.ts
+++ b/packages/jasmine/runner.ts
@@ -1,17 +1,20 @@
 import { Validator } from './matcher.model';
-import { Describer, TestCase, Context } from './describe.model';
+import { TestCase, Context } from './describe.model';
 import { Callback } from './jasmine.model';
-import { InnerMethods, TestsResults, TestCaseResult } from './runner.model';
+import {
+    InnerMethods,
+    TestsResults,
+    TestCaseResult,
+    TestCaseResults,
+} from './runner.model';
+import { Store } from './store';
 
 export class Runner {
-    private activeDescriberId: string;
-    private activeTestCaseIndex: number;
-    private rootDescribersId: Array<string> = [];
-    private describers: Array<Describer> = [];
+    constructor(private store: Store) {}
 
-    public run(): TestsResults {
-        return this.performDecribers(this.rootDescribersId, []);
-    }
+    public run = (): TestsResults => {
+        return this.performDecribers(this.store.rootDescribersId, []);
+    };
 
     private performDecribers(
         describersIds: Array<string>,
@@ -34,13 +37,13 @@ export class Runner {
             description,
             context,
             childrenDescribersId,
-        } = this.describers[describerId];
+        } = this.store.describers[describerId];
 
         this.setActiveDescriberId(describerId);
 
         beforeEachList.forEach((cb: Callback): void => cb.call(context));
 
-        const testCaseResults = testCases.map(
+        const testCaseResults: TestCaseResults = testCases.map(
             this.performTestAndReturnItsResult.bind(this, context)
         );
 
@@ -74,11 +77,11 @@ export class Runner {
     }
 
     private setActiveDescriberId(describerId: string): void {
-        this.activeDescriberId = describerId;
+        this.store.activeDescriberId = describerId;
     }
 
     private setActiveTestCaseIndex(index: number): void {
-        this.activeTestCaseIndex = index;
+        this.store.activeTestCaseIndex = index;
     }
 
     public getMethods(): InnerMethods {

--- a/packages/jasmine/store.ts
+++ b/packages/jasmine/store.ts
@@ -1,0 +1,19 @@
+import { Describers, NextDescriberArguments } from './describe.model';
+
+export interface Store {
+    activeDescriberId: string;
+    isDescriberFormingInProgress: boolean;
+    describers: Describers;
+    rootDescribersId: Array<string>;
+    activeTestCaseIndex: number;
+    nextDescriberArguments: Array<NextDescriberArguments>;
+}
+
+export const store: Store = {
+    activeDescriberId: null,
+    isDescriberFormingInProgress: false,
+    describers: {},
+    rootDescribersId: [],
+    activeTestCaseIndex: null,
+    nextDescriberArguments: [],
+};


### PR DESCRIPTION
directly set matcher results instead of storing matcher callback to call it once the matcher result will be required 
remove/clean up no more used inner methods since level of components' coupling was reduced with store integration