### PR TITLE
add support to prevent too long test's executions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1404,6 +1404,12 @@
                 "@types/lodash": "*"
             }
         },
+        "@types/node": {
+            "version": "13.13.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+            "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
+            "dev": true
+        },
         "@types/prettier": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@babel/preset-typescript": "^7.9.0",
         "@types/jest": "^25.2.1",
         "@types/lodash.uniqueid": "^4.0.6",
+        "@types/node": "^13.13.4",
         "@typescript-eslint/eslint-plugin": "^2.29.0",
         "@typescript-eslint/parser": "^2.29.0",
         "coveralls": "^3.0.12",

--- a/packages/jasmine/async-utils.ts
+++ b/packages/jasmine/async-utils.ts
@@ -3,7 +3,9 @@ import {
     AsyncMapCallback,
     AsyncReduce,
     AsyncReduceCallback,
+    Resolve,
 } from './models/async-utils.model';
+import { ValidatorResult } from './models/matchers.model';
 
 export const asyncMap: AsyncMap = async <InitialElement, ResultElement>(
     list: Array<InitialElement>,
@@ -31,4 +33,20 @@ export const asyncReduce: AsyncReduce = async <Result, InitialElement>(
     }
 
     return result;
+};
+
+export const availableAsyncCallbackPerormanceDelay = 100; //ms
+export const getPromseResolvedInAvailableTimeFrame = (
+    errorMessage: string,
+    availableAsyncCallbackPerormanceDelay: number
+): Promise<ValidatorResult> => {
+    let resolve: Resolve;
+    const promise = new Promise((res: Resolve) => (resolve = res));
+
+    setTimeout(
+        () => resolve({ isSuccess: false, errorMessage }),
+        availableAsyncCallbackPerormanceDelay
+    );
+
+    return promise;
 };

--- a/packages/jasmine/error.messages.ts
+++ b/packages/jasmine/error.messages.ts
@@ -5,6 +5,9 @@ import {
 } from './models/error.messages.model';
 import { ExpectedResult, ActualResult } from './models/matchers.model';
 
+export const testTimeFrameDurationExeeded: ErrorMessageCallback = (
+    actualResult: ActualResult
+) => `async test takes more than available ${JSON.stringify(actualResult)}ms`;
 export const expectDoNothing: ErrorMessageCallback = (
     actualResult: ActualResult
 ) =>
@@ -15,6 +18,7 @@ export const toBeTruthy: ErrorMessageCallback = (actualResult: ActualResult) =>
     `expected ${JSON.stringify(actualResult)} to be truthy`;
 
 export const errorMessages: ErrorMessages = {
+    testTimeFrameDurationExeeded,
     expectDoNothing,
     toBeFalsy,
     toBeTruthy,

--- a/packages/jasmine/matchers.ts
+++ b/packages/jasmine/matchers.ts
@@ -10,6 +10,7 @@ import { Validators } from './validators';
 import { ValidatorMethod } from './models/validators.model';
 
 export enum MatchersTypes {
+    testTimeFrameDurationExeeded = 'testTimeFrameDurationExeeded',
     expectDoNothing = 'expectDoNothing',
     toBeFalsy = 'toBeFalsy',
     toBeTruthy = 'toBeTruthy',

--- a/packages/jasmine/mock/integration.mock.ts
+++ b/packages/jasmine/mock/integration.mock.ts
@@ -20,8 +20,8 @@ export const getTestInstanceWithMockData = () => {
         instance.expect('without matcher');
     };
     const itCallbackSecond = async () => {
-        await asyncMethod(150);
         instance.expect('valid').toBeTruthy();
+        await asyncMethod(150);
     };
     const itCallbackThird = () => {};
     const itCallbackFourth = async () => {

--- a/packages/jasmine/mock/integration.mock.ts
+++ b/packages/jasmine/mock/integration.mock.ts
@@ -13,30 +13,31 @@ export const getTestInstanceWithMockData = () => {
     const afeCallbackSecond = () => {};
     const afeCallbackThird = () => {};
 
-    const asyncMethod = () => Promise.resolve();
+    const asyncMethod = (delay: number) =>
+        new Promise((res) => setTimeout(res, delay));
 
     const itCallbackFirst = () => {
         instance.expect('without matcher');
     };
     const itCallbackSecond = async () => {
-        await asyncMethod();
+        await asyncMethod(150);
         instance.expect('valid').toBeTruthy();
     };
-    const itCallbackThird = () => {
-        instance.expect('invalid').toBeFalsy();
-    };
+    const itCallbackThird = () => {};
     const itCallbackFourth = async () => {
-        await asyncMethod();
         instance.expect(false).toBeFalsy();
+        await asyncMethod(30);
+
         instance.expect(undefined).toBeFalsy();
         instance.expect(null).toBeFalsy();
     };
     const itCallbackFifth = () => {
+        instance.expect('invalid').toBeFalsy();
         instance.expect('valid').toBeTruthy();
     };
     const itCallbackSixth = async () => {
         instance.expect(0).toBeFalsy();
-        await asyncMethod();
+        await asyncMethod(1);
         instance.expect('').toBeFalsy();
     };
 

--- a/packages/jasmine/models/async-utils.model.ts
+++ b/packages/jasmine/models/async-utils.model.ts
@@ -1,3 +1,5 @@
+import { ValidatorResult } from './matchers.model';
+
 /**
  * async map
  */
@@ -27,3 +29,5 @@ export type AsyncReduce = <InitialElement, Result>(
     asyncCallback: AsyncReduceCallback<Result, InitialElement>,
     initialResult: Result
 ) => Promise<Result>;
+
+export type Resolve = (validatorResult: ValidatorResult) => void;

--- a/packages/jasmine/tests/async-utils.test.ts
+++ b/packages/jasmine/tests/async-utils.test.ts
@@ -1,4 +1,9 @@
-import { asyncMap, asyncReduce } from '../async-utils';
+import {
+    asyncMap,
+    asyncReduce,
+    availableAsyncCallbackPerormanceDelay,
+    getPromseResolvedInAvailableTimeFrame,
+} from '../async-utils';
 import {
     AsyncMapCallback,
     AsyncReduceCallback,
@@ -52,6 +57,21 @@ describe('#asyncReduce', () => {
             '3': 9,
             '4': 16,
             '5': 25,
+        });
+    });
+});
+
+describe('#getPromseResolvedInAvailableTimeFrame', () => {
+    it('should return promise which will be resolved after passed delay with error message', async () => {
+        const errorMessage = 'errorMessage';
+        expect(
+            await getPromseResolvedInAvailableTimeFrame(
+                errorMessage,
+                availableAsyncCallbackPerormanceDelay
+            )
+        ).toEqual({
+            isSuccess: false,
+            errorMessage,
         });
     });
 });

--- a/packages/jasmine/tests/error.messages.test.ts
+++ b/packages/jasmine/tests/error.messages.test.ts
@@ -1,13 +1,19 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import {
     errorMessages,
     expectDoNothing,
     toBeFalsy,
     toBeTruthy,
     getErrorMessage,
+    testTimeFrameDurationExeeded,
 } from '../error.messages';
 
 describe('errorMessages', () => {
     it('should contain error messages for all matchers', () => {
+        expect(errorMessages.testTimeFrameDurationExeeded).toBe(
+            testTimeFrameDurationExeeded
+        );
         expect(errorMessages.expectDoNothing).toBe(expectDoNothing);
         expect(errorMessages.toBeFalsy).toBe(toBeFalsy);
         expect(errorMessages.toBeTruthy).toBe(toBeTruthy);

--- a/packages/jasmine/tests/jasmine.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.integration.test.ts
@@ -173,104 +173,107 @@ describe('results validation', () => {
 
     it('should return valid results even for async it cases', async () => {
         const results = await instance.run();
+        const [root1, child2, child3, child4, root5, child6] = results;
+        expect(root1).toEqual({
+            description: 'root-1',
+            testCaseResults: [
+                {
+                    itDescription: 'it-1',
+                    validatorResults: [
+                        {
+                            isSuccess: false,
+                            errorMessage:
+                                'looks like this expect does nothing with: "without matcher"',
+                        },
+                    ],
+                },
+                {
+                    itDescription: 'it-2',
+                    validatorResults: [
+                        {
+                            errorMessage:
+                                'async test takes more than available 100ms',
+                            isSuccess: false,
+                        },
+                    ],
+                },
+            ],
+        });
 
-        expect(results).toEqual([
-            {
-                description: 'root-1',
-                testCaseResults: [
-                    {
-                        itDescription: 'it-1',
-                        validatorResults: [
-                            {
-                                isSuccess: false,
-                                errorMessage:
-                                    'looks like this expect does nothing with: "without matcher"',
-                            },
-                        ],
-                    },
-                    {
-                        itDescription: 'it-2',
-                        validatorResults: [
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                description: 'child-2',
-                testCaseResults: [],
-            },
-            {
-                description: 'child-3',
-                testCaseResults: [
-                    {
-                        itDescription: 'it-3',
-                        validatorResults: [
-                            {
-                                isSuccess: false,
-                                errorMessage: 'expected "invalid" to be falsy',
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                description: 'child-4',
-                testCaseResults: [
-                    {
-                        itDescription: 'it-4',
-                        validatorResults: [
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                description: 'root-5',
-                testCaseResults: [
-                    {
-                        itDescription: 'it-5',
-                        validatorResults: [
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                description: 'child-6',
-                testCaseResults: [
-                    {
-                        itDescription: 'it-6',
-                        validatorResults: [
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                            {
-                                isSuccess: true,
-                                errorMessage: '',
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]);
+        expect(child2).toEqual({
+            description: 'child-2',
+            testCaseResults: [],
+        });
+
+        expect(child3).toEqual({
+            description: 'child-3',
+            testCaseResults: [
+                {
+                    itDescription: 'it-3',
+                    validatorResults: [],
+                },
+            ],
+        });
+
+        expect(child4).toEqual({
+            description: 'child-4',
+            testCaseResults: [
+                {
+                    itDescription: 'it-4',
+                    validatorResults: [
+                        {
+                            isSuccess: true,
+                            errorMessage: '',
+                        },
+                        {
+                            isSuccess: true,
+                            errorMessage: '',
+                        },
+                        {
+                            isSuccess: true,
+                            errorMessage: '',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        expect(root5).toEqual({
+            description: 'root-5',
+            testCaseResults: [
+                {
+                    itDescription: 'it-5',
+                    validatorResults: [
+                        {
+                            errorMessage: 'expected "invalid" to be falsy',
+                            isSuccess: false,
+                        },
+                        {
+                            isSuccess: true,
+                            errorMessage: '',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        expect(child6).toEqual({
+            description: 'child-6',
+            testCaseResults: [
+                {
+                    itDescription: 'it-6',
+                    validatorResults: [
+                        {
+                            isSuccess: true,
+                            errorMessage: '',
+                        },
+                        {
+                            isSuccess: true,
+                            errorMessage: '',
+                        },
+                    ],
+                },
+            ],
+        });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "jest"],
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",


### PR DESCRIPTION
rise testPerformsDurationExceeded validator issue and set it instead of actual expect validators result to prevent endless loading for async test