### PR TITLE
add negative matchers functionality

### DIFF
--- a/packages/jasmine/error.messages.ts
+++ b/packages/jasmine/error.messages.ts
@@ -5,17 +5,35 @@ import {
 } from './models/error.messages.model';
 import { ExpectedResult, ActualResult } from './models/matchers.model';
 
+export const getNotMessage = (isNot: boolean): string =>
+    isNot ? ' not ' : ' ';
+
 export const testTimeFrameDurationExeeded: ErrorMessageCallback = (
+    isNot: boolean,
     actualResult: ActualResult
 ) => `async test takes more than available ${JSON.stringify(actualResult)}ms`;
+
 export const expectDoNothing: ErrorMessageCallback = (
+    isNot: boolean,
     actualResult: ActualResult
 ) =>
     `looks like this expect does nothing with: ${JSON.stringify(actualResult)}`;
-export const toBeFalsy: ErrorMessageCallback = (actualResult: ActualResult) =>
-    `expected ${JSON.stringify(actualResult)} to be falsy`;
-export const toBeTruthy: ErrorMessageCallback = (actualResult: ActualResult) =>
-    `expected ${JSON.stringify(actualResult)} to be truthy`;
+
+export const toBeFalsy: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult
+) =>
+    `expected ${JSON.stringify(actualResult)}${getNotMessage(
+        isNot
+    )}to be falsy`;
+
+export const toBeTruthy: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult
+) =>
+    `expected ${JSON.stringify(actualResult)}${getNotMessage(
+        isNot
+    )}to be truthy`;
 
 export const errorMessages: ErrorMessages = {
     testTimeFrameDurationExeeded,
@@ -27,7 +45,8 @@ export const errorMessages: ErrorMessages = {
 export const getErrorMessage: GetErrorMessage = (
     isSuccess: boolean,
     errorMessageCallback: ErrorMessageCallback,
+    isNot: boolean,
     actualResult: ActualResult,
     expectedResult?: ExpectedResult
 ): string =>
-    isSuccess ? '' : errorMessageCallback(actualResult, expectedResult);
+    isSuccess ? '' : errorMessageCallback(isNot, actualResult, expectedResult);

--- a/packages/jasmine/expect.ts
+++ b/packages/jasmine/expect.ts
@@ -39,6 +39,7 @@ export class Expect {
             validatorResult: {
                 isSuccess: false,
                 errorMessage: errorMessages[MatchersTypes.expectDoNothing](
+                    false,
                     actualResult
                 ),
             },

--- a/packages/jasmine/mock/integration.mock.ts
+++ b/packages/jasmine/mock/integration.mock.ts
@@ -3,7 +3,7 @@
 import { Jasmine } from '../jasmine';
 
 export const getTestInstanceWithMockData = () => {
-    const instance: any = new Jasmine();
+    const instance = new Jasmine();
 
     const bfeCallbackFirst = () => {};
     const bfeCallbackSecond = () => {};
@@ -32,8 +32,8 @@ export const getTestInstanceWithMockData = () => {
         instance.expect(null).toBeFalsy();
     };
     const itCallbackFifth = () => {
-        instance.expect('invalid').toBeFalsy();
-        instance.expect('valid').toBeTruthy();
+        instance.expect('invalid').not.toBeFalsy();
+        instance.expect('valid').not.toBeTruthy();
     };
     const itCallbackSixth = async () => {
         instance.expect(0).toBeFalsy();

--- a/packages/jasmine/models/error.messages.model.ts
+++ b/packages/jasmine/models/error.messages.model.ts
@@ -2,6 +2,7 @@ import { ExpectedResult, ActualResult } from './matchers.model';
 import { MatchersTypes } from '../matchers';
 
 export type ErrorMessageCallback = (
+    isNot: boolean,
     expectedResult: ExpectedResult,
     actualResult?: ActualResult
 ) => string;
@@ -13,6 +14,7 @@ export type ErrorMessages = {
 export type GetErrorMessage = (
     isSuccess: boolean,
     errorMessageCallback: ErrorMessageCallback,
+    isNot: boolean,
     expectedResult: ExpectedResult,
     actualResult?: ActualResult
 ) => string;

--- a/packages/jasmine/models/matchers.model.ts
+++ b/packages/jasmine/models/matchers.model.ts
@@ -16,6 +16,7 @@ export interface Validator {
 
 export type MatcherMethod = (...expectedResult: Array<ExpectedResult>) => void;
 export interface MatchersCore {
+    not: MatchersCore;
     toBeTruthy: MatcherMethod;
     toBeFalsy: MatcherMethod;
 }

--- a/packages/jasmine/models/validators.model.ts
+++ b/packages/jasmine/models/validators.model.ts
@@ -1,10 +1,6 @@
-import {
-    ExpectedResult,
-    ActualResult,
-    ValidatorResult,
-} from './matchers.model';
+import { ExpectedResult, ActualResult } from './matchers.model';
 
 export type ValidatorMethod = (
     actualResult: ActualResult,
     ...expectedResults: Array<ExpectedResult>
-) => ValidatorResult;
+) => boolean;

--- a/packages/jasmine/runner.ts
+++ b/packages/jasmine/runner.ts
@@ -99,6 +99,7 @@ export class Runner {
         );
         const errorTestPerofomrancePromise = getPromseResolvedInAvailableTimeFrame(
             errorMessages.testTimeFrameDurationExeeded(
+                false,
                 availableAsyncCallbackPerormanceDelay
             ),
             availableAsyncCallbackPerormanceDelay

--- a/packages/jasmine/tests/error.messages.test.ts
+++ b/packages/jasmine/tests/error.messages.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
+    getNotMessage,
     errorMessages,
     expectDoNothing,
     toBeFalsy,
@@ -8,6 +9,16 @@ import {
     getErrorMessage,
     testTimeFrameDurationExeeded,
 } from '../error.messages';
+
+describe('#getNotMessage', () => {
+    it('should return string with space if isNot is not set', () => {
+        expect(getNotMessage(false)).toBe(' ');
+    });
+
+    it('should return string with not if isNot is set', () => {
+        expect(getNotMessage(true)).toBe(' not ');
+    });
+});
 
 describe('errorMessages', () => {
     it('should contain error messages for all matchers', () => {
@@ -20,13 +31,23 @@ describe('errorMessages', () => {
     });
 });
 
-const expectedValue = 'expectedValue';
+const actualResult = 'actualResult';
+
+describe('#testTimeFrameDurationExeeded', () => {
+    it('should return valid message based on passed value', () => {
+        expect(testTimeFrameDurationExeeded(false, actualResult)).toBe(
+            `async test takes more than available ${JSON.stringify(
+                actualResult
+            )}ms`
+        );
+    });
+});
 
 describe('#expectDoNothing', () => {
     it('should return valid message based on passed value', () => {
-        expect(expectDoNothing(expectedValue)).toBe(
+        expect(expectDoNothing(false, actualResult)).toBe(
             `looks like this expect does nothing with: ${JSON.stringify(
-                expectedValue
+                actualResult
             )}`
         );
     });
@@ -34,16 +55,23 @@ describe('#expectDoNothing', () => {
 
 describe('#toBeFalsy', () => {
     it('should return valid message based on passed value', () => {
-        expect(toBeFalsy(expectedValue)).toBe(
-            `expected ${JSON.stringify(expectedValue)} to be falsy`
+        expect(toBeFalsy(false, actualResult)).toBe(
+            `expected ${JSON.stringify(actualResult)} to be falsy`
+        );
+
+        expect(toBeFalsy(true, actualResult)).toBe(
+            `expected ${JSON.stringify(actualResult)} not to be falsy`
         );
     });
 });
 
 describe('#toBeTruthy', () => {
     it('should return valid message based on passed value', () => {
-        expect(toBeTruthy(expectedValue)).toBe(
-            `expected ${JSON.stringify(expectedValue)} to be truthy`
+        expect(toBeTruthy(false, actualResult)).toBe(
+            `expected ${JSON.stringify(actualResult)} to be truthy`
+        );
+        expect(toBeTruthy(true, actualResult)).toBe(
+            `expected ${JSON.stringify(actualResult)} not to be truthy`
         );
     });
 });
@@ -66,6 +94,7 @@ describe('#getErrorMessage', () => {
             getErrorMessage(
                 true,
                 errorMessageCallback,
+                true,
                 actualResult,
                 expectedResult
             )
@@ -76,22 +105,25 @@ describe('#getErrorMessage', () => {
         getErrorMessage(
             true,
             errorMessageCallback,
+            true,
             actualResult,
             expectedResult
         );
         expect(errorMessageCallback).not.toHaveBeenCalled();
     });
 
-    it('should return call errorMessage callback with actual and expected result and form valid error message with them', () => {
+    it('should return call of errorMessage callback with actual and expected result and form valid error message with them', () => {
         expect(
             getErrorMessage(
                 false,
                 errorMessageCallback,
+                true,
                 actualResult,
                 expectedResult
             )
         ).toBe(errorMessage);
         expect(errorMessageCallback).toHaveBeenCalledWith(
+            true,
             actualResult,
             expectedResult
         );

--- a/packages/jasmine/tests/jasmine.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.integration.test.ts
@@ -245,12 +245,12 @@ describe('results validation', () => {
                     itDescription: 'it-5',
                     validatorResults: [
                         {
-                            errorMessage: 'expected "invalid" to be falsy',
-                            isSuccess: false,
-                        },
-                        {
                             isSuccess: true,
                             errorMessage: '',
+                        },
+                        {
+                            errorMessage: 'expected "valid" not to be truthy',
+                            isSuccess: false,
                         },
                     ],
                 },

--- a/packages/jasmine/tests/matchers.test.ts
+++ b/packages/jasmine/tests/matchers.test.ts
@@ -22,7 +22,7 @@ describe('Matchers', () => {
     });
 
     beforeEach(() => {
-        matchers = new Matchers(validator, validators);
+        matchers = new Matchers(validator, validators, false);
     });
 
     it('should set error message methdod on init', () => {
@@ -36,6 +36,15 @@ describe('Matchers', () => {
 
     it('should define validator on init', () => {
         expect(matchers.validator).toBe(validator);
+        expect(matchers.isNot).toBeFalsy();
+    });
+
+    it('should define validator on init with negative validators', () => {
+        expect(matchers.not.validator).toBe(validator);
+        expect(matchers.not.isNot).toBeTruthy();
+        expect(matchers.not.toBeFalsy).toBeDefined();
+        expect(matchers.not.toBeTruthy).toBeDefined();
+        expect(matchers.not.getErrorMessage).toBe(getErrorMessage);
     });
 
     describe('#getValidator', () => {
@@ -90,10 +99,30 @@ describe('Matchers', () => {
             expect(matchers.getErrorMessage).toHaveBeenCalledWith(
                 isSuccess,
                 expectDoNothing,
+                false,
                 actualResult
             );
             expect(matchers.setValidatorResult).toHaveBeenCalledWith({
                 isSuccess,
+                errorMessage,
+            });
+        });
+
+        it('should set validator result with negative results if valdiator called from "NOT"', () => {
+            matchers.isNot = true;
+            matchers.getValidator(
+                validatorMethod,
+                MatchersTypes.expectDoNothing
+            )(...expectedResults);
+
+            expect(matchers.getErrorMessage).toHaveBeenCalledWith(
+                false,
+                expectDoNothing,
+                true,
+                actualResult
+            );
+            expect(matchers.setValidatorResult).toHaveBeenCalledWith({
+                isSuccess: false,
                 errorMessage,
             });
         });
@@ -110,6 +139,26 @@ describe('Matchers', () => {
         it('should set validator result to validator', () => {
             matchers.setValidatorResult(validatorResult);
             expect(validator.validatorResult).toBe(validatorResult);
+        });
+    });
+
+    describe('#setNotField', () => {
+        let setNotField: any;
+        let context: any;
+
+        beforeEach(() => {
+            setNotField = matchers.setNotField;
+            context = {};
+        });
+
+        it('should do nothing if isNot already defined', () => {
+            setNotField.call(context, validator, validators, true);
+            expect(context).toEqual({});
+        });
+
+        it('should set not field on instance with new matchers instane ', () => {
+            setNotField.call(context, validator, validators, false);
+            expect(context.not.isNot).toBeTruthy();
         });
     });
 });

--- a/packages/jasmine/tests/validators.test.ts
+++ b/packages/jasmine/tests/validators.test.ts
@@ -1,17 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { Validators } from '../validators';
-import { getErrorMessage, errorMessages } from '../error.messages';
 
 describe('Validators', () => {
     let validators: any;
 
     beforeEach(() => {
         validators = new Validators();
-    });
-
-    it('should set error message methdo on init', () => {
-        expect(validators.getErrorMessage).toBe(getErrorMessage);
     });
 
     describe('validators:', () => {
@@ -27,48 +22,30 @@ describe('Validators', () => {
         });
 
         describe('#toBeFalsy', () => {
-            it('should return error message', () => {
-                expect(validators.toBeFalsy().errorMessage).toBe(errorMessage);
-                expect(getErrorMessageSpy).toHaveBeenCalledWith(
-                    true,
-                    errorMessages.toBeFalsy,
-                    undefined
-                );
-            });
-
             it('should reurn succes result if actual result is falsy', () => {
-                expect(validators.toBeFalsy().isSuccess).toBeTruthy();
-                expect(validators.toBeFalsy('').isSuccess).toBeTruthy();
-                expect(validators.toBeFalsy(null).isSuccess).toBeTruthy();
-                expect(validators.toBeFalsy(0).isSuccess).toBeTruthy();
-                expect(validators.toBeFalsy(false).isSuccess).toBeTruthy();
+                expect(validators.toBeFalsy()).toBeTruthy();
+                expect(validators.toBeFalsy('')).toBeTruthy();
+                expect(validators.toBeFalsy(null)).toBeTruthy();
+                expect(validators.toBeFalsy(0)).toBeTruthy();
+                expect(validators.toBeFalsy(false)).toBeTruthy();
             });
 
             it('should reurn failure result if actual result is truthy', () => {
-                expect(validators.toBeFalsy(true).isSuccess).toBeFalsy();
+                expect(validators.toBeFalsy(true)).toBeFalsy();
             });
         });
 
         describe('#toBeTruthy', () => {
-            it('should return error message', () => {
-                expect(validators.toBeTruthy().errorMessage).toBe(errorMessage);
-                expect(getErrorMessageSpy).toHaveBeenCalledWith(
-                    false,
-                    errorMessages.toBeTruthy,
-                    undefined
-                );
-            });
-
             it('should reurn succes result if actual result is falsy', () => {
-                expect(validators.toBeTruthy(true).isSuccess).toBeTruthy();
-                expect(validators.toBeTruthy(' ').isSuccess).toBeTruthy();
-                expect(validators.toBeTruthy([]).isSuccess).toBeTruthy();
-                expect(validators.toBeTruthy({}).isSuccess).toBeTruthy();
-                expect(validators.toBeTruthy(Function).isSuccess).toBeTruthy();
+                expect(validators.toBeTruthy(true)).toBeTruthy();
+                expect(validators.toBeTruthy(' ')).toBeTruthy();
+                expect(validators.toBeTruthy([])).toBeTruthy();
+                expect(validators.toBeTruthy({})).toBeTruthy();
+                expect(validators.toBeTruthy(Function)).toBeTruthy();
             });
 
             it('should reurn failure result if actual result is truthy', () => {
-                expect(validators.toBeTruthy(false).isSuccess).toBeFalsy();
+                expect(validators.toBeTruthy(false)).toBeFalsy();
             });
         });
     });

--- a/packages/jasmine/validators.ts
+++ b/packages/jasmine/validators.ts
@@ -1,39 +1,16 @@
-import { errorMessages, getErrorMessage } from './error.messages';
-import { ValidatorResult, ActualResult } from './models/matchers.model';
-import { MatchersTypes } from './matchers';
-import { GetErrorMessage } from './models/error.messages.model';
+import { ActualResult } from './models/matchers.model';
 import { ValidatorMethod } from './models/validators.model';
 
 export class Validators {
-    private getErrorMessage: GetErrorMessage = getErrorMessage;
-
     public toBeFalsy: ValidatorMethod = (
         actualResult: ActualResult
-    ): ValidatorResult => {
-        const isSuccess = !actualResult;
-
-        return {
-            isSuccess,
-            errorMessage: this.getErrorMessage(
-                isSuccess,
-                errorMessages[MatchersTypes.toBeFalsy],
-                actualResult
-            ),
-        };
+    ): boolean => {
+        return !actualResult;
     };
 
     public toBeTruthy: ValidatorMethod = (
         actualResult: ActualResult
-    ): ValidatorResult => {
-        const isSuccess = Boolean(actualResult);
-
-        return {
-            isSuccess,
-            errorMessage: this.getErrorMessage(
-                isSuccess,
-                errorMessages[MatchersTypes.toBeTruthy],
-                actualResult
-            ),
-        };
+    ): boolean => {
+        return Boolean(actualResult);
     };
 }


### PR DESCRIPTION
1.  prepare validators to return only simple boolean results
2. move logic with forming of validators result to common generic method
3. add support negative matchers functionality (**.not.toBe.**) in common method
4. adapt error messages to work with negative functionality
5. actualize/updates tests for negative functionality