### PR TITLE
#29 fix issue: pass bfe/afe to child

### DIFF
--- a/packages/jasmine/mock/integration.mock.ts
+++ b/packages/jasmine/mock/integration.mock.ts
@@ -13,15 +13,22 @@ export const getTestInstanceWithMockData = () => {
     let spyWithReturnedvalue: any;
     let spyWithMockImplementation: any;
 
+    let initialValueBfeFirst: number;
+    let initialValueBfeSecond: number;
+    let initialValueBfeThird: number;
+
     const bfeCallbackFirst = () => {
+        initialValueBfeFirst = 10;
         simpleSpy = createSpy('simpleSpy');
     };
     const bfeCallbackSecond = () => {
+        initialValueBfeSecond = initialValueBfeFirst + 10;
         spyWithReturnedvalue = createSpy('spyWithReturnedvalue').returnValue(
             returnValue
         );
     };
     const bfeCallbackThird = () => {
+        initialValueBfeThird = initialValueBfeSecond + 10;
         spyWithMockImplementation = createSpy(
             'spyWithMockImplementation'
         ).callFake((arrayOfWords: Array<string>) =>
@@ -51,6 +58,7 @@ export const getTestInstanceWithMockData = () => {
                 spyWithMockImplementation(['it', ' ', 'w', 'o', 'r', 'k', 's'])
             )
             .toBeFalsy();
+        instance.expect(initialValueBfeThird).toBeFalsy();
     };
     const itCallbackFourth = async () => {
         instance.expect(false).toBeFalsy();

--- a/packages/jasmine/models/describe.model.ts
+++ b/packages/jasmine/models/describe.model.ts
@@ -26,7 +26,13 @@ export interface Describers {
     [describerId: string]: Describer;
 }
 
-export interface NextDescriberArguments {
+export interface ParentMethods {
+    beforeEachList: CallbackList;
+    afterEachList: CallbackList;
+}
+
+export interface DescriberArguments {
     description: string;
     callback: Callback;
+    parentMethods: ParentMethods;
 }

--- a/packages/jasmine/models/store.model.ts
+++ b/packages/jasmine/models/store.model.ts
@@ -1,4 +1,4 @@
-import { Describers, NextDescriberArguments } from './describe.model';
+import { Describers, DescriberArguments } from './describe.model';
 
 export interface Store {
     activeDescriberId: string;
@@ -6,5 +6,5 @@ export interface Store {
     describers: Describers;
     rootDescribersId: Array<string>;
     activeTestCaseIndex: number;
-    nextDescriberArguments: Array<NextDescriberArguments>;
+    nextDescriberArguments: Array<DescriberArguments>;
 }

--- a/packages/jasmine/tests/describe.test.ts
+++ b/packages/jasmine/tests/describe.test.ts
@@ -208,7 +208,7 @@ describe('Describe', () => {
             );
         });
 
-        it('#1 should set formed describer with parent bfe/afe methods', () => {
+        it('#29 should set formed describer with parent bfe/afe methods', () => {
             instance.initDescribe(describerArguments);
             const [[initDescriber]] = instance.setFormedDescriber.mock.calls;
             expect(initDescriber.beforeEachList).toEqual([parentBfeMethods]);

--- a/packages/jasmine/tests/jasmine.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.integration.test.ts
@@ -75,7 +75,7 @@ describe('Integration tests: Describe', () => {
         it('"child-2": should form valid relationship structure of describers', () => {
             expect(instance.store.describers['child-2']).toEqual({
                 description: 'child-2',
-                beforeEachList: [],
+                beforeEachList: [bfeCallbackFirst, bfeCallbackSecond],
                 afterEachList: [afeCallbackFirst],
                 testCases: [],
                 childrenDescribersId: ['child-3'],
@@ -86,8 +86,12 @@ describe('Integration tests: Describe', () => {
         it('"child-3": should form valid relationship structure of describers', () => {
             expect(instance.store.describers['child-3']).toEqual({
                 description: 'child-3',
-                beforeEachList: [bfeCallbackThird],
-                afterEachList: [afeCallbackSecond],
+                beforeEachList: [
+                    bfeCallbackFirst,
+                    bfeCallbackSecond,
+                    bfeCallbackThird,
+                ],
+                afterEachList: [afeCallbackFirst, afeCallbackSecond],
                 testCases: [
                     {
                         it: { description: 'it-3', callback: itCallbackThird },
@@ -102,7 +106,7 @@ describe('Integration tests: Describe', () => {
         it('"child-4": should form valid relationship structure of describers', () => {
             expect(instance.store.describers['child-4']).toEqual({
                 description: 'child-4',
-                beforeEachList: [],
+                beforeEachList: [bfeCallbackFirst, bfeCallbackSecond],
                 afterEachList: [],
                 testCases: [
                     {
@@ -221,6 +225,10 @@ describe('results validation', () => {
                     validatorResults: [
                         {
                             errorMessage: 'expected "it works" to be falsy',
+                            isSuccess: false,
+                        },
+                        {
+                            errorMessage: 'expected 30 to be falsy',
                             isSuccess: false,
                         },
                     ],


### PR DESCRIPTION
__Root reason:__ was not implemented yet.
__Details:__ each describer contains its own scope of methods defined in the local scope of each callback. It means bfe/afe methods were storied independently in each describer and did not pass from parent to chide describer.

__Fix:__
1. pass bfe/afe methods from parent describer as #parentMetods to each child describer
2. each child describer afe/bfe extends as list of parent methods plus it own
3. refactor interfaces for describerArguments to remove prefix, since its now used as arguments for each describer
4. actualize integration tests based on issue criteria