### PR TITLE
implement xdescribe and xit methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This repo demonstrates core concepts of modern/popular JS libraries
 ## packages
 
 -   express (core principies and imitation their communication on any request)
--   jasmine/jest (core concepts describe/beforeEach/afterEach/it/expect/matchers/spy and their communication on test run)
+-   jasmine/jest (core concepts (x)describe/beforeEach/afterEach/(x)it/expect/matchers/spy and their communication on test run)

--- a/packages/jasmine/describe.ts
+++ b/packages/jasmine/describe.ts
@@ -11,6 +11,11 @@ import { Store } from './models/store.model';
 export class Describe implements DescribeCore {
     constructor(private store: Store) {}
 
+    public xdescribe = (description: string): void => {
+        const { store } = this;
+        store.inactiveDescribers = [...store.inactiveDescribers, description];
+    };
+
     public describe = (description: string, callback: Callback): void => {
         this.describeHandler({
             description,

--- a/packages/jasmine/inner-describe.methods.ts
+++ b/packages/jasmine/inner-describe.methods.ts
@@ -5,6 +5,11 @@ import { Store } from './models/store.model';
 export class InnerDescribeMethods implements InnerDescribeMethodsCore {
     constructor(private store: Store) {}
 
+    public xit = (description: string): void => {
+        const { store } = this;
+        store.inactiveTestCases = [...store.inactiveTestCases, description];
+    };
+
     public beforeEach = (callback: Callback): void => {
         const describer = this.getActiveDescriber();
         describer.beforeEachList = [...describer.beforeEachList, callback];

--- a/packages/jasmine/jasmine.ts
+++ b/packages/jasmine/jasmine.ts
@@ -20,14 +20,18 @@ export class Jasmine implements JasmineCore {
         describers: {},
         rootDescribersId: [],
         nextDescriberArguments: [],
+        inactiveDescribers: [],
+        inactiveTestCases: [],
     };
 
     public describe: DescribeModel;
+    public xdescribe: DescribeModel;
 
     public beforeEach: BeforeAfterEachModel;
     public afterEach: BeforeAfterEachModel;
 
     public it: ItModel;
+    public xit: ItModel;
 
     public expect: ExpectModel;
 
@@ -36,6 +40,7 @@ export class Jasmine implements JasmineCore {
     constructor() {
         const describeInstance = new Describe(this.store);
         this.describe = describeInstance.describe;
+        this.xdescribe = describeInstance.xdescribe;
 
         const innerDescribeMethodsInstance = new InnerDescribeMethods(
             this.store
@@ -44,6 +49,7 @@ export class Jasmine implements JasmineCore {
         this.beforeEach = innerDescribeMethodsInstance.beforeEach;
 
         this.it = innerDescribeMethodsInstance.it;
+        this.xit = innerDescribeMethodsInstance.xit;
 
         const expectInstance = new Expect(this.store);
         this.expect = expectInstance.expect;

--- a/packages/jasmine/models/describe.model.ts
+++ b/packages/jasmine/models/describe.model.ts
@@ -34,5 +34,5 @@ export interface ParentMethods {
 export interface DescriberArguments {
     description: string;
     callback: Callback;
-    parentMethods: ParentMethods;
+    parentMethods?: ParentMethods;
 }

--- a/packages/jasmine/models/jasmine.model.ts
+++ b/packages/jasmine/models/jasmine.model.ts
@@ -1,5 +1,5 @@
 import { MatchersCore, ActualResult } from './matchers.model';
-import { TestsResults } from './runner.model';
+import { TestResultsWithDisabledMethods } from './runner.model';
 
 export type Callback = () => void;
 export type CallbackList = Array<Callback>;
@@ -7,6 +7,7 @@ export type CallbackList = Array<Callback>;
 export type DescribeModel = (description: string, callback: Callback) => void;
 export interface DescribeCore {
     describe: DescribeModel;
+    xdescribe: DescribeModel;
 }
 
 export type BeforeAfterEachModel = (callback: Callback) => void;
@@ -15,6 +16,7 @@ export interface InnerDescribeMethodsCore {
     beforeEach: BeforeAfterEachModel;
     afterEach: BeforeAfterEachModel;
     it: ItModel;
+    xit: ItModel;
 }
 
 export type ExpectModel = (actualResult: ActualResult) => MatchersCore;
@@ -22,7 +24,7 @@ export interface ExpectCore {
     expect: ExpectModel;
 }
 
-export type RunModel = () => Promise<TestsResults>;
+export type RunModel = () => Promise<TestResultsWithDisabledMethods>;
 export interface RunCore {
     run: RunModel;
 }

--- a/packages/jasmine/models/runner.model.ts
+++ b/packages/jasmine/models/runner.model.ts
@@ -11,3 +11,13 @@ export interface TestResults {
     testCaseResults: Array<TestCaseResult>;
 }
 export type TestsResults = Array<TestResults>;
+
+export interface DisabledMethods {
+    describers: Array<string>;
+    testCases: Array<string>;
+}
+
+export interface TestResultsWithDisabledMethods {
+    testsResults: TestsResults;
+    disabledMethods: DisabledMethods;
+}

--- a/packages/jasmine/models/store.model.ts
+++ b/packages/jasmine/models/store.model.ts
@@ -7,4 +7,6 @@ export interface Store {
     rootDescribersId: Array<string>;
     activeTestCaseIndex: number;
     nextDescriberArguments: Array<DescriberArguments>;
+    inactiveDescribers: Array<string>;
+    inactiveTestCases: Array<string>;
 }

--- a/packages/jasmine/runner.ts
+++ b/packages/jasmine/runner.ts
@@ -13,14 +13,26 @@ import {
     TestsResults,
     TestCaseResult,
     TestCaseResults,
+    TestResultsWithDisabledMethods,
 } from './models/runner.model';
 import { Store } from './models/store.model';
 
 export class Runner {
     constructor(private store: Store) {}
 
-    public run = async (): Promise<TestsResults> => {
-        return await this.performDecribers(this.store.rootDescribersId, []);
+    public run = async (): Promise<TestResultsWithDisabledMethods> => {
+        const testsResults = await this.performDecribers(
+            this.store.rootDescribersId,
+            []
+        );
+
+        return {
+            testsResults,
+            disabledMethods: {
+                describers: [...this.store.inactiveDescribers],
+                testCases: [...this.store.inactiveTestCases],
+            },
+        };
     };
 
     private async performDecribers(

--- a/packages/jasmine/store.ts
+++ b/packages/jasmine/store.ts
@@ -7,4 +7,6 @@ export const store: Store = {
     rootDescribersId: [],
     activeTestCaseIndex: null,
     nextDescriberArguments: [],
+    inactiveDescribers: [],
+    inactiveTestCases: [],
 };

--- a/packages/jasmine/tests/describe.test.ts
+++ b/packages/jasmine/tests/describe.test.ts
@@ -22,6 +22,20 @@ describe('Describe', () => {
         describer = 'describer';
     });
 
+    describe('#xdescribe', () => {
+        it('should store disabled describer description in state', () => {
+            const disabledDescriberDescription = 'disabledDescriberDescription';
+            instance.store.inactiveDescribers = [disabledDescriberDescription];
+
+            instance.xdescribe(description, callback);
+
+            expect(instance.store.inactiveDescribers).toEqual([
+                disabledDescriberDescription,
+                description,
+            ]);
+        });
+    });
+
     describe('#describe', () => {
         beforeEach(() => {
             instance.describeHandler = jest.fn().mockName('describeHandler');

--- a/packages/jasmine/tests/inner-describe.methods.test.ts
+++ b/packages/jasmine/tests/inner-describe.methods.test.ts
@@ -27,6 +27,20 @@ describe('InnerDescribeMethods', () => {
         };
     });
 
+    describe('#xit', () => {
+        it('should store disabled test case description in state', () => {
+            const disabledTestCaseDescription = 'disabledTestCaseDescription';
+            instance.store.inactiveTestCases = [disabledTestCaseDescription];
+
+            instance.xit(description, callback);
+
+            expect(instance.store.inactiveTestCases).toEqual([
+                disabledTestCaseDescription,
+                description,
+            ]);
+        });
+    });
+
     describe('#beforeEach', () => {
         beforeEach(() => {
             instance.getActiveDescriber = jest

--- a/packages/jasmine/tests/jasmine.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.integration.test.ts
@@ -176,8 +176,8 @@ describe('results validation', () => {
     });
 
     it('should return valid results even for async it cases', async () => {
-        const results = await instance.run();
-        const [root1, child2, child3, child4, root5, child6] = results;
+        const { testsResults } = await instance.run();
+        const [root1, child2, child3, child4, root5, child6] = testsResults;
         expect(root1).toEqual({
             description: 'root-1',
             testCaseResults: [

--- a/packages/jasmine/tests/runner.test.ts
+++ b/packages/jasmine/tests/runner.test.ts
@@ -21,22 +21,34 @@ describe('Runner', () => {
     describe('#run', () => {
         const rootDescribersId = 'rootDescribersId';
         const performDescribersResult = 'performDescribersResult';
+        const disabledDescriber = 'disabledDescriber';
+        const disabledTestCase = 'disabledTestCase';
 
         beforeEach(() => {
-            instance.performDecribers = jest.fn().mockName('performDecribers');
+            instance.performDecribers = jest
+                .fn()
+                .mockName('performDecribers')
+                .mockReturnValue(performDescribersResult);
             instance.store.rootDescribersId = rootDescribersId;
+
+            instance.store.inactiveDescribers = [disabledDescriber];
+            instance.store.inactiveTestCases = [disabledTestCase];
         });
 
-        it('should return async list of results for all tests', async () => {
-            instance.performDecribers.mockReturnValue(performDescribersResult);
+        it('should async return list of results for all tests', async () => {
+            const { testsResults } = await instance.run();
 
-            const results = await instance.run();
-
-            expect(results).toBe(performDescribersResult);
+            expect(testsResults).toBe(performDescribersResult);
             expect(instance.performDecribers).toHaveBeenCalledWith(
                 rootDescribersId,
                 []
             );
+        });
+
+        it('should return result including tests cases and description of disabled describers and test cases', async () => {
+            const { disabledMethods } = await instance.run();
+            expect(disabledMethods.describers).toEqual([disabledDescriber]);
+            expect(disabledMethods.testCases).toEqual([disabledTestCase]);
         });
     });
 


### PR DESCRIPTION
add support of disabled methods to exclude tests if it needs.
**Important:** list of disabled items contains only disabled methods which could be reached
```
describe('describerA', () => {
  
  it('testA', () => {})
  xit('testB', () => {})
  xdescribe('describeB', () => {
    xit('testC', () => {})
  })
})
```

will return next:
```
expect(run().disabledMethods.describers).toEqual(['describeB])
expect(run().disabledMethods.testCases).toEqual(['testB])
```

`testC` - cannot be reached due to it's placed in the already disabled parent describer.
Once parent describer will be enabled the methods could be found in the list of disabled test cases.

The goal is to simple return actual data without complex implementation of calculation  nested describers/test cases, etc.