### PR TITLE
preparation to support validation of spies

### DIFF
--- a/packages/jasmine/error.messages.ts
+++ b/packages/jasmine/error.messages.ts
@@ -35,11 +35,56 @@ export const toBeTruthy: ErrorMessageCallback = (
         isNot
     )}to be truthy`;
 
+export const toBe: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult,
+    [expectedResult]: Array<ExpectedResult>
+) =>
+    `expected ${JSON.stringify(actualResult)}${getNotMessage(
+        isNot
+    )}to be ${JSON.stringify(expectedResult)}`;
+
+export const toEqual: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult,
+    [expectedResult]: Array<ExpectedResult>
+) =>
+    `expected ${JSON.stringify(actualResult)}${getNotMessage(
+        isNot
+    )}to equal ${JSON.stringify(expectedResult)}`;
+
+export const toHaveBeenCalled: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult
+) =>
+    `expected ${JSON.stringify(actualResult)}${getNotMessage(
+        isNot
+    )}to have been called`;
+
+export const toHaveBeenCalledWith: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult,
+    ...expectedResult: Array<ExpectedResult>
+) =>
+    `expected ${JSON.stringify(actualResult)}${getNotMessage(
+        isNot
+    )}to have been called with ${JSON.stringify(expectedResult)}`;
+
+export const expectSpy: ErrorMessageCallback = (
+    isNot: boolean,
+    actualResult: ActualResult
+) => `expected spy but got ${JSON.stringify(actualResult)}`;
+
 export const errorMessages: ErrorMessages = {
+    expectSpy,
     testTimeFrameDurationExeeded,
     expectDoNothing,
     toBeFalsy,
     toBeTruthy,
+    toBe,
+    toEqual,
+    toHaveBeenCalled,
+    toHaveBeenCalledWith,
 };
 
 export const getErrorMessage: GetErrorMessage = (
@@ -47,6 +92,6 @@ export const getErrorMessage: GetErrorMessage = (
     errorMessageCallback: ErrorMessageCallback,
     isNot: boolean,
     actualResult: ActualResult,
-    expectedResult?: ExpectedResult
+    ...expectedResult: Array<ExpectedResult>
 ): string =>
     isSuccess ? '' : errorMessageCallback(isNot, actualResult, expectedResult);

--- a/packages/jasmine/matchers.ts
+++ b/packages/jasmine/matchers.ts
@@ -14,10 +14,15 @@ import { GetActualResultWithSpy } from './models/utils.model';
 import { getActualResultWithSpy } from './utils';
 
 export enum MatchersTypes {
+    expectSpy = 'expectSpy',
     testTimeFrameDurationExeeded = 'testTimeFrameDurationExeeded',
     expectDoNothing = 'expectDoNothing',
     toBeFalsy = 'toBeFalsy',
     toBeTruthy = 'toBeTruthy',
+    toBe = 'toBe',
+    toEqual = 'toEqual',
+    toHaveBeenCalled = 'toHaveBeenCalled',
+    toHaveBeenCalledWith = 'toHaveBeenCalledWith',
 }
 
 export class Matchers implements MatchersCore {
@@ -48,7 +53,7 @@ export class Matchers implements MatchersCore {
 
     private getValidator(
         validatorMethod: ValidatorMethod,
-        errorMessageType: MatchersTypes
+        matcherType: MatchersTypes
     ): (expectedResults: Array<ExpectedResult>) => void {
         return (...expectedResults: Array<ExpectedResult>): void => {
             const actualResult = this.getActualResult();
@@ -64,9 +69,10 @@ export class Matchers implements MatchersCore {
                 isSuccess,
                 errorMessage: this.getErrorMessage(
                     isSuccess,
-                    errorMessages[errorMessageType],
+                    errorMessages[matcherType],
                     this.isNot,
-                    actualResult
+                    actualResult,
+                    ...expectedResults
                 ),
             });
         };

--- a/packages/jasmine/models/error.messages.model.ts
+++ b/packages/jasmine/models/error.messages.model.ts
@@ -3,8 +3,8 @@ import { MatchersTypes } from '../matchers';
 
 export type ErrorMessageCallback = (
     isNot: boolean,
-    expectedResult: ExpectedResult,
-    actualResult?: ActualResult
+    actualResult: ActualResult,
+    ...expectedResult: Array<ExpectedResult>
 ) => string;
 
 export type ErrorMessages = {
@@ -15,6 +15,6 @@ export type GetErrorMessage = (
     isSuccess: boolean,
     errorMessageCallback: ErrorMessageCallback,
     isNot: boolean,
-    expectedResult: ExpectedResult,
-    actualResult?: ActualResult
+    actualResult: ActualResult,
+    ...expectedResult: Array<ExpectedResult>
 ) => string;

--- a/packages/jasmine/tests/error.messages.test.ts
+++ b/packages/jasmine/tests/error.messages.test.ts
@@ -8,6 +8,11 @@ import {
     toBeTruthy,
     getErrorMessage,
     testTimeFrameDurationExeeded,
+    toBe,
+    toEqual,
+    toHaveBeenCalled,
+    toHaveBeenCalledWith,
+    expectSpy,
 } from '../error.messages';
 
 describe('#getNotMessage', () => {
@@ -28,10 +33,16 @@ describe('errorMessages', () => {
         expect(errorMessages.expectDoNothing).toBe(expectDoNothing);
         expect(errorMessages.toBeFalsy).toBe(toBeFalsy);
         expect(errorMessages.toBeTruthy).toBe(toBeTruthy);
+        expect(errorMessages.toBe).toBe(toBe);
+        expect(errorMessages.toEqual).toBe(toEqual);
+        expect(errorMessages.toHaveBeenCalled).toBe(toHaveBeenCalled);
+        expect(errorMessages.toHaveBeenCalledWith).toBe(toHaveBeenCalledWith);
+        expect(errorMessages.expectSpy).toBe(expectSpy);
     });
 });
 
 const actualResult = 'actualResult';
+const expectedResult = 'expectedResult';
 
 describe('#testTimeFrameDurationExeeded', () => {
     it('should return valid message based on passed value', () => {
@@ -72,6 +83,73 @@ describe('#toBeTruthy', () => {
         );
         expect(toBeTruthy(true, actualResult)).toBe(
             `expected ${JSON.stringify(actualResult)} not to be truthy`
+        );
+    });
+});
+
+describe('#toBe', () => {
+    it('should return valid message based on passed value', () => {
+        expect(toBe(false, actualResult, [expectedResult])).toBe(
+            `expected ${JSON.stringify(actualResult)} to be ${JSON.stringify(
+                expectedResult
+            )}`
+        );
+        expect(toBe(true, actualResult, [expectedResult])).toBe(
+            `expected ${JSON.stringify(
+                actualResult
+            )} not to be ${JSON.stringify(expectedResult)}`
+        );
+    });
+});
+
+describe('#toEqual', () => {
+    it('should return valid message based on passed value', () => {
+        expect(toEqual(false, actualResult, [expectedResult])).toBe(
+            `expected ${JSON.stringify(actualResult)} to equal ${JSON.stringify(
+                expectedResult
+            )}`
+        );
+        expect(toEqual(true, actualResult, [expectedResult])).toBe(
+            `expected ${JSON.stringify(
+                actualResult
+            )} not to equal ${JSON.stringify(expectedResult)}`
+        );
+    });
+});
+
+describe('#toHaveBeenCalled', () => {
+    it('should return valid message based on passed value', () => {
+        expect(toHaveBeenCalled(false, actualResult)).toBe(
+            `expected ${JSON.stringify(actualResult)} to have been called`
+        );
+        expect(toHaveBeenCalled(true, actualResult)).toBe(
+            `expected ${JSON.stringify(actualResult)} not to have been called`
+        );
+    });
+});
+
+describe('#toHaveBeenCalledWith', () => {
+    it('should return valid message based on passed value', () => {
+        expect(toHaveBeenCalledWith(false, actualResult, expectedResult)).toBe(
+            `expected ${JSON.stringify(
+                actualResult
+            )} to have been called with ${JSON.stringify([expectedResult])}`
+        );
+        expect(toHaveBeenCalledWith(true, actualResult, expectedResult)).toBe(
+            `expected ${JSON.stringify(
+                actualResult
+            )} not to have been called with ${JSON.stringify([expectedResult])}`
+        );
+    });
+});
+
+describe('#expectSpy', () => {
+    it('should return valid message based on passed value', () => {
+        expect(expectSpy(false, actualResult)).toBe(
+            `expected spy but got ${JSON.stringify(actualResult)}`
+        );
+        expect(expectSpy(true, actualResult)).toBe(
+            `expected spy but got ${JSON.stringify(actualResult)}`
         );
     });
 });
@@ -122,10 +200,8 @@ describe('#getErrorMessage', () => {
                 expectedResult
             )
         ).toBe(errorMessage);
-        expect(errorMessageCallback).toHaveBeenCalledWith(
-            true,
-            actualResult,
-            expectedResult
-        );
+        expect(errorMessageCallback).toHaveBeenCalledWith(true, actualResult, [
+            expectedResult,
+        ]);
     });
 });

--- a/packages/jasmine/tests/matchers.test.ts
+++ b/packages/jasmine/tests/matchers.test.ts
@@ -100,7 +100,8 @@ describe('Matchers', () => {
                 isSuccess,
                 expectDoNothing,
                 false,
-                actualResult
+                actualResult,
+                ...expectedResults
             );
             expect(matchers.setValidatorResult).toHaveBeenCalledWith({
                 isSuccess,
@@ -119,7 +120,8 @@ describe('Matchers', () => {
                 false,
                 expectDoNothing,
                 true,
-                actualResult
+                actualResult,
+                ...expectedResults
             );
             expect(matchers.setValidatorResult).toHaveBeenCalledWith({
                 isSuccess: false,


### PR DESCRIPTION
1. add error messages methods for future spy validators
2. rename second argument to more convenient to simpler adaptation to `expectSpy` validation
3. add missed argument for error message methods with expected results and update its interface to support multiple expected results for future `toHaveBeenCalled`
4. tests for new implemented functionality 