### PR TITLE
add middleware to support spy validators only for passed spy

### DIFF
--- a/packages/jasmine/matchers.ts
+++ b/packages/jasmine/matchers.ts
@@ -5,13 +5,14 @@ import {
     ExpectedResult,
     ActualResult,
     MatcherMethod,
+    VaidatorResultWithErrorCallback,
 } from './models/matchers.model';
 import { Validators } from './validators';
 import { ValidatorMethod } from './models/validators.model';
 import { errorMessages, getErrorMessage } from './error.messages';
 import { GetErrorMessage } from './models/error.messages.model';
-import { GetActualResultWithSpy } from './models/utils.model';
-import { getActualResultWithSpy } from './utils';
+import { GetActualResultWithSpy, IsSpy } from './models/utils.model';
+import { getActualResultWithSpy, isSpy } from './utils';
 
 export enum MatchersTypes {
     expectSpy = 'expectSpy',
@@ -25,9 +26,15 @@ export enum MatchersTypes {
     toHaveBeenCalledWith = 'toHaveBeenCalledWith',
 }
 
+const spyMatchers: Array<MatchersTypes> = [
+    MatchersTypes.toHaveBeenCalled,
+    MatchersTypes.toHaveBeenCalledWith,
+];
+
 export class Matchers implements MatchersCore {
     public not: MatchersCore;
 
+    private isSpy: IsSpy = isSpy;
     private getErrorMessage: GetErrorMessage = getErrorMessage;
     private getActualResultWithSpy: GetActualResultWithSpy = getActualResultWithSpy;
 
@@ -56,25 +63,78 @@ export class Matchers implements MatchersCore {
         matcherType: MatchersTypes
     ): (expectedResults: Array<ExpectedResult>) => void {
         return (...expectedResults: Array<ExpectedResult>): void => {
-            const actualResult = this.getActualResult();
-            const validatorMethodResult = validatorMethod(
+            this.setValidatorResult(
+                this.getValidatorResult(
+                    validatorMethod,
+                    matcherType,
+                    expectedResults
+                )
+            );
+        };
+    }
+
+    private getValidatorResult(
+        validatorMethod: ValidatorMethod,
+        matcherType: MatchersTypes,
+        expectedResults: Array<ExpectedResult>
+    ): ValidatorResult {
+        const actualResult = this.getActualResult();
+
+        const { isSuccess, errorMessageCallback } = this.isExpectedSpyNotPassed(
+            actualResult,
+            matcherType
+        )
+            ? this.getExpectedSpyNotPassedValidatorResult()
+            : this.getValidatorResultWithErrorCallback(
+                  validatorMethod,
+                  actualResult,
+                  matcherType,
+                  expectedResults
+              );
+
+        return {
+            isSuccess,
+            errorMessage: this.getErrorMessage(
+                isSuccess,
+                errorMessageCallback,
+                this.isNot,
                 actualResult,
                 ...expectedResults
-            );
-            const isSuccess = this.isNot
-                ? !validatorMethodResult
-                : validatorMethodResult;
+            ),
+        };
+    }
 
-            this.setValidatorResult({
-                isSuccess,
-                errorMessage: this.getErrorMessage(
-                    isSuccess,
-                    errorMessages[matcherType],
-                    this.isNot,
-                    actualResult,
-                    ...expectedResults
-                ),
-            });
+    private getValidatorResultWithErrorCallback(
+        validatorMethod: ValidatorMethod,
+        actualResult: ActualResult,
+        matcherType: MatchersTypes,
+        expectedResults: Array<ExpectedResult>
+    ): VaidatorResultWithErrorCallback {
+        const validatorMethodResult = validatorMethod(
+            actualResult,
+            ...expectedResults
+        );
+        const isSuccess = this.isNot
+            ? !validatorMethodResult
+            : validatorMethodResult;
+
+        return {
+            isSuccess,
+            errorMessageCallback: errorMessages[matcherType],
+        };
+    }
+
+    private isExpectedSpyNotPassed(
+        actualResult: ActualResult,
+        matcherType: MatchersTypes
+    ): boolean {
+        return !this.isSpy(actualResult) && spyMatchers.includes(matcherType);
+    }
+
+    private getExpectedSpyNotPassedValidatorResult(): VaidatorResultWithErrorCallback {
+        return {
+            isSuccess: false,
+            errorMessageCallback: errorMessages[MatchersTypes.expectSpy],
         };
     }
 

--- a/packages/jasmine/models/matchers.model.ts
+++ b/packages/jasmine/models/matchers.model.ts
@@ -1,3 +1,5 @@
+import { ErrorMessageCallback } from './error.messages.model';
+
 export interface ValidatorResult {
     isSuccess: boolean;
     errorMessage?: string;
@@ -19,4 +21,9 @@ export interface MatchersCore {
     not: MatchersCore;
     toBeTruthy: MatcherMethod;
     toBeFalsy: MatcherMethod;
+}
+
+export interface VaidatorResultWithErrorCallback {
+    isSuccess: boolean;
+    errorMessageCallback: ErrorMessageCallback;
 }

--- a/packages/jasmine/models/utils.model.ts
+++ b/packages/jasmine/models/utils.model.ts
@@ -1,5 +1,6 @@
 import { ActualResult } from './matchers.model';
 
+export type IsSpy = (actualResult: ActualResult) => boolean;
 export type GetActualResultWithSpy = (
     actualResult: ActualResult
 ) => ActualResult;

--- a/packages/jasmine/tests/utils.test.ts
+++ b/packages/jasmine/tests/utils.test.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { getActualResultWithSpy } from '../utils';
+import { isSpy, getActualResultWithSpy } from '../utils';
+
+describe('#isSpy', () => {
+    it('should return true if passed actual result is spy', () => {
+        expect(isSpy({ getSpyResult: true })).toBeTruthy();
+    });
+
+    it('should return false if passed actual result is spy', () => {
+        expect(isSpy(undefined)).toBeFalsy();
+    });
+});
 
 describe('#getActualResultWithSpy', () => {
     const actualResult = 'actualResult';

--- a/packages/jasmine/utils.ts
+++ b/packages/jasmine/utils.ts
@@ -1,13 +1,16 @@
 import { ActualResult } from './models/matchers.model';
 import { SpyAPICore } from './models/spy-api.model';
-import { GetActualResultWithSpy } from './models/utils.model';
+import { GetActualResultWithSpy, IsSpy } from './models/utils.model';
+
+export const isSpy: IsSpy = (actualResult: ActualResult): boolean =>
+    actualResult && Boolean(actualResult.getSpyResult);
 
 export const getActualResultWithSpy: GetActualResultWithSpy = (
     actualResult: ActualResult
 ): ActualResult => {
     let result = actualResult;
 
-    if (actualResult && actualResult.getSpyResult) {
+    if (isSpy(actualResult)) {
         result = (actualResult as SpyAPICore).getSpyResult();
     }
 


### PR DESCRIPTION
1. refactoring utils to reuse #isSpy 
2. add middleware to prevent call spy validators in case if actual result is not spy to filter this type user issues in one place without increasing of validators complexity