### PR TITLE
implement #fit to support chosen test cases 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This repo demonstrates core concepts of modern/popular JS libraries
 ## packages
 
 -   express (core principies and imitation their communication on any request)
--   jasmine/jest (core concepts (x)describe/beforeEach/afterEach/(x)it/expect/matchers/spy and their communication on test run)
+-   jasmine/jest (core concepts (x)describe/beforeEach/afterEach/(x/f)it/expect/matchers/spy and their communication on test run)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo demonstrates core concepts of modern/popular JS libraries
 ## packages
 
 -   express (core principies and imitation their communication on any request)
--   jasmine/jest:
+-   jasmine/jest(test framefork functionality):
     -   (x)describe
     -   beforeEach/afterEach
     -   (x/f)it

--- a/README.md
+++ b/README.md
@@ -6,4 +6,13 @@ This repo demonstrates core concepts of modern/popular JS libraries
 ## packages
 
 -   express (core principies and imitation their communication on any request)
--   jasmine/jest (core concepts (x)describe/beforeEach/afterEach/(x/f)it/expect/matchers/spy and their communication on test run)
+-   jasmine/jest:
+    -   (x)describe
+    -   beforeEach/afterEach
+    -   (x/f)it
+    -   expect
+    -   toBe/toEqual
+    -   toBeFalsy/toBeTruthy
+    -   toHaveBennCalled/toHaveBennCalledWith
+    -   createSpy/spyMethod,
+    -   async tests cases

--- a/packages/jasmine/jasmine.ts
+++ b/packages/jasmine/jasmine.ts
@@ -32,6 +32,7 @@ export class Jasmine implements JasmineCore {
 
     public it: ItModel;
     public xit: ItModel;
+    public fit: ItModel;
 
     public expect: ExpectModel;
 
@@ -50,6 +51,7 @@ export class Jasmine implements JasmineCore {
 
         this.it = innerDescribeMethodsInstance.it;
         this.xit = innerDescribeMethodsInstance.xit;
+        this.fit = innerDescribeMethodsInstance.fit;
 
         const expectInstance = new Expect(this.store);
         this.expect = expectInstance.expect;

--- a/packages/jasmine/models/jasmine.model.ts
+++ b/packages/jasmine/models/jasmine.model.ts
@@ -17,6 +17,7 @@ export interface InnerDescribeMethodsCore {
     afterEach: BeforeAfterEachModel;
     it: ItModel;
     xit: ItModel;
+    fit: ItModel;
 }
 
 export type ExpectModel = (actualResult: ActualResult) => MatchersCore;

--- a/packages/jasmine/models/store.model.ts
+++ b/packages/jasmine/models/store.model.ts
@@ -5,6 +5,7 @@ export interface Store {
     isDescriberFormingInProgress: boolean;
     describers: Describers;
     rootDescribersId: Array<string>;
+    fDescribersId: Array<string>;
     activeTestCaseIndex: number;
     nextDescriberArguments: Array<DescriberArguments>;
     inactiveDescribers: Array<string>;

--- a/packages/jasmine/runner.ts
+++ b/packages/jasmine/runner.ts
@@ -21,16 +21,25 @@ export class Runner {
     constructor(private store: Store) {}
 
     public run = async (): Promise<TestResultsWithDisabledMethods> => {
-        const testsResults = await this.performDecribers(
-            this.store.rootDescribersId,
-            []
-        );
+        const { store } = this;
+        const {
+            rootDescribersId,
+            fDescribersId,
+            inactiveDescribers,
+            inactiveTestCases,
+        } = store;
+
+        const describersId = fDescribersId.length
+            ? fDescribersId
+            : rootDescribersId;
+
+        const testsResults = await this.performDecribers(describersId, []);
 
         return {
             testsResults,
             disabledMethods: {
-                describers: [...this.store.inactiveDescribers],
-                testCases: [...this.store.inactiveTestCases],
+                describers: [...inactiveDescribers],
+                testCases: [...inactiveTestCases],
             },
         };
     };
@@ -87,6 +96,7 @@ export class Runner {
         const { it } = testCase;
         this.setActiveTestCaseIndex(index);
 
+        this.initValidators(testCase);
         const errorValidatorResult = await this.asyncCallbackHanlder(
             it.callback,
             context
@@ -119,6 +129,10 @@ export class Runner {
         );
 
         return Promise.race([callbackPromise, errorTestPerofomrancePromise]);
+    }
+
+    private initValidators(testCase: TestCase): void {
+        testCase.validators = [];
     }
 
     private setActiveDescriberId(describerId: string): void {

--- a/packages/jasmine/store.ts
+++ b/packages/jasmine/store.ts
@@ -5,6 +5,7 @@ export const store: Store = {
     isDescriberFormingInProgress: false,
     describers: {},
     rootDescribersId: [],
+    fDescribersId: [],
     activeTestCaseIndex: null,
     nextDescriberArguments: [],
     inactiveDescribers: [],

--- a/packages/jasmine/tests/inner-describe.methods.test.ts
+++ b/packages/jasmine/tests/inner-describe.methods.test.ts
@@ -27,6 +27,37 @@ describe('InnerDescribeMethods', () => {
         };
     });
 
+    describe('#fit', () => {
+        const fDescriber = 'fDescriber';
+
+        beforeEach(() => {
+            instance.getActiveDescriber = jest
+                .fn()
+                .mockName('getActiveDescriber')
+                .mockReturnValue(describer);
+            instance.getFDescriber = jest
+                .fn()
+                .mockName('getFDescriber')
+                .mockReturnValue(fDescriber);
+            instance.registerFDescriber = jest
+                .fn()
+                .mockName('registerFDescriber');
+        });
+
+        it('should form fDescriber from active describer and register it in the collection of describers', () => {
+            instance.fit(description, callback);
+
+            expect(instance.getActiveDescriber).toHaveBeenCalled();
+            expect(instance.getFDescriber).toHaveBeenCalledWith(describer, {
+                description,
+                callback,
+            });
+            expect(instance.registerFDescriber).toHaveBeenCalledWith(
+                fDescriber
+            );
+        });
+    });
+
     describe('#xit', () => {
         it('should store disabled test case description in state', () => {
             const disabledTestCaseDescription = 'disabledTestCaseDescription';
@@ -103,6 +134,46 @@ describe('InnerDescribeMethods', () => {
 
         it('should return active describer', () => {
             expect(instance.getActiveDescriber()).toBe(describer);
+        });
+    });
+
+    describe('#getFDescriber', () => {
+        it('should return fDescriber contains bfe/afe lists of passed describers', () => {
+            const it: any = 'it';
+
+            expect(instance.getFDescriber(describer, it)).toEqual({
+                beforeEachList: [existedBeforeEachCallback],
+                afterEachList: [existedAfterEachCallback],
+                childrenDescribersId: [],
+                context: {},
+                testCases: [
+                    {
+                        it,
+                        validators: [],
+                    },
+                ],
+            });
+        });
+    });
+
+    describe('#registerFDescriber', () => {
+        const existedFDescriberId: any = 'existedFDescriberId';
+
+        beforeEach(() => {
+            instance.store.describers = { existedDescribers: true };
+            instance.store.fDescribersId = [existedFDescriberId];
+        });
+
+        it('should set passed fDescriber to existed describers and set its Id in the fDescriberId list', () => {
+            instance.registerFDescriber(describer);
+            expect(instance.store.describers).toEqual({
+                existedDescribers: true,
+                'fdescr-1': describer,
+            });
+            expect(instance.store.fDescribersId).toEqual([
+                existedFDescriberId,
+                'fdescr-1',
+            ]);
         });
     });
 });

--- a/packages/jasmine/tests/jasmine.test.ts
+++ b/packages/jasmine/tests/jasmine.test.ts
@@ -10,11 +10,18 @@ describe('Jasmine', () => {
     });
 
     it('should define test API', () => {
-        expect(instance.expect).toBeDefined();
-        expect(instance.it).toBeDefined();
+        expect(instance.describe).toBeDefined();
+        expect(instance.xdescribe).toBeDefined();
+
         expect(instance.beforeEach).toBeDefined();
         expect(instance.afterEach).toBeDefined();
-        expect(instance.describe).toBeDefined();
+
+        expect(instance.it).toBeDefined();
+        expect(instance.xit).toBeDefined();
+        expect(instance.fit).toBeDefined();
+
+        expect(instance.expect).toBeDefined();
+
         expect(instance.run).toBeDefined();
     });
 });

--- a/packages/jasmine/tests/jasmine.xf.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.xf.integration.test.ts
@@ -1,0 +1,271 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Jasmine } from '../jasmine';
+
+const instance = new Jasmine();
+
+let a: any;
+
+const cb1 = (): any => {};
+const cb2 = (): any => {};
+const cb3 = (): any => {};
+const cb4 = (): any => {
+    a = 10;
+};
+const cb5 = (): any => {
+    instance.expect(a).toBe(10);
+};
+const cb6 = (): any => {};
+const cb7 = (): any => {
+    a = a * 2;
+};
+const cb8 = (): any => {
+    instance.expect(a).toBe(20);
+};
+const cb9 = (): any => {};
+const cb10 = (): any => {};
+
+instance.xdescribe('disabled describer', () => {
+    instance.it('is not registered', cb1);
+});
+
+instance.describe('1 enabled describer', () => {
+    instance.xit('disasbled test case', cb2);
+    instance.it('1 enabled test case', cb3);
+});
+
+instance.describe('2 enabled describer', () => {
+    instance.beforeEach(cb4);
+    instance.fit('1 chosen test case', cb5);
+    instance.it('2 enabled test case', cb6);
+
+    instance.describe('enabled nested describer with chosen test case', () => {
+        instance.beforeEach(cb7);
+        instance.fit('2 chosen test case', cb8);
+    });
+
+    instance.describe(
+        'enabled nested describer without chosen test case',
+        () => {
+            instance.it('3 enabled test case', cb9);
+        }
+    );
+
+    instance.fit('3 chosen test case', cb10);
+});
+
+const getDescriberById = (instance: any, describerId: string): any =>
+    instance.store.describers[describerId];
+
+describe('test of enabled/disabled/chosen test cases', () => {
+    it('root-1: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'root-1')).toEqual({
+            afterEachList: [],
+            beforeEachList: [],
+            childrenDescribersId: [],
+            context: {},
+            description: '1 enabled describer',
+            testCases: [
+                {
+                    it: {
+                        callback: cb3,
+                        description: '1 enabled test case',
+                    },
+                    validators: [],
+                },
+            ],
+        });
+    });
+
+    it('root-2: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'root-2')).toEqual({
+            afterEachList: [],
+            beforeEachList: [cb4],
+            childrenDescribersId: ['child-5', 'child-7'],
+            context: {},
+            description: '2 enabled describer',
+            testCases: [
+                {
+                    it: {
+                        callback: cb6,
+                        description: '2 enabled test case',
+                    },
+                    validators: [],
+                },
+            ],
+        });
+    });
+
+    it('child-5: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'child-5')).toEqual({
+            afterEachList: [],
+            beforeEachList: [cb4, cb7],
+            childrenDescribersId: [],
+            context: {},
+            description: 'enabled nested describer with chosen test case',
+            testCases: [],
+        });
+    });
+
+    it('child-7: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'child-7')).toEqual({
+            afterEachList: [],
+            beforeEachList: [cb4],
+            childrenDescribersId: [],
+            context: {},
+            description: 'enabled nested describer without chosen test case',
+            testCases: [
+                {
+                    it: {
+                        callback: cb9,
+                        description: '3 enabled test case',
+                    },
+                    validators: [],
+                },
+            ],
+        });
+    });
+
+    it('fdescr-3: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'fdescr-3')).toEqual({
+            afterEachList: [],
+            beforeEachList: [cb4],
+            childrenDescribersId: [],
+            context: {},
+            description: '2 enabled describer',
+            testCases: [
+                {
+                    it: {
+                        callback: cb5,
+                        description: '1 chosen test case',
+                    },
+                    validators: [],
+                },
+            ],
+        });
+    });
+
+    it('fdescr-4: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'fdescr-4')).toEqual({
+            afterEachList: [],
+            beforeEachList: [cb4],
+            childrenDescribersId: [],
+            context: {},
+            description: '2 enabled describer',
+            testCases: [
+                {
+                    it: {
+                        callback: cb10,
+                        description: '3 chosen test case',
+                    },
+                    validators: [],
+                },
+            ],
+        });
+    });
+
+    it('fdescr-6: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'fdescr-6')).toEqual({
+            afterEachList: [],
+            beforeEachList: [cb4, cb7],
+            childrenDescribersId: [],
+            context: {},
+            description: 'enabled nested describer with chosen test case',
+            testCases: [
+                {
+                    it: {
+                        callback: cb8,
+                        description: '2 chosen test case',
+                    },
+                    validators: [],
+                },
+            ],
+        });
+    });
+});
+
+describe('test for forming root describer/fdescriber Ids', () => {
+    it('should form valid list of rootDescribersId', () => {
+        expect((instance as any).store.rootDescribersId).toEqual([
+            'root-1',
+            'root-2',
+        ]);
+    });
+
+    it('should form valid list of rootFDescribersId', () => {
+        expect((instance as any).store.fDescribersId).toEqual([
+            'fdescr-3',
+            'fdescr-4',
+            'fdescr-6',
+        ]);
+    });
+});
+
+const getAsyncResultsByIndex = async (
+    results: any,
+    index: number
+): Promise<any> => {
+    const { testsResults } = await results;
+    return testsResults[index];
+};
+
+describe('test for validation of test results with enabled/disabled/chosen test cases', () => {
+    it('should return valid list of disabled describers and test cases', async () => {
+        const { disabledMethods } = await instance.run();
+        expect(disabledMethods.describers).toEqual(['disabled describer']);
+        expect(disabledMethods.testCases).toEqual(['disasbled test case']);
+    });
+
+    it('should return only results of chosen test cases if they exists', async () => {
+        const { testsResults } = await instance.run();
+        expect(testsResults.length).toBe(3);
+    });
+
+    it('should return valid results of chosen test cases', async () => {
+        const { testsResults } = await instance.run();
+        expect(testsResults.length).toBe(3);
+    });
+
+    describe('validate results of chosen test cases', () => {
+        it('1 chosen test case: should return valid result', async () => {
+            expect(await getAsyncResultsByIndex(instance.run(), 0)).toEqual({
+                description: '2 enabled describer',
+                testCaseResults: [
+                    {
+                        itDescription: '1 chosen test case',
+                        validatorResults: [
+                            { errorMessage: '', isSuccess: true },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it('3 chosen test case: should return valid result', async () => {
+            expect(await getAsyncResultsByIndex(instance.run(), 1)).toEqual({
+                description: '2 enabled describer',
+                testCaseResults: [
+                    {
+                        itDescription: '3 chosen test case',
+                        validatorResults: [],
+                    },
+                ],
+            });
+        });
+
+        it('2 chosen test case: should return valid result', async () => {
+            expect(await getAsyncResultsByIndex(instance.run(), 2)).toEqual({
+                description: 'enabled nested describer with chosen test case',
+                testCaseResults: [
+                    {
+                        itDescription: '2 chosen test case',
+                        validatorResults: [
+                            { errorMessage: '', isSuccess: true },
+                        ],
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/packages/jasmine/tests/runner.test.ts
+++ b/packages/jasmine/tests/runner.test.ts
@@ -219,6 +219,7 @@ describe('Runner', () => {
             instance.setActiveTestCaseIndex = jest
                 .fn()
                 .mockName('setActiveTestCaseIndex');
+            instance.initValidators = jest.fn().mockName('initValidators');
             instance.asyncCallbackHanlder = jest
                 .fn()
                 .mockName('asyncCallbackHanlder');
@@ -275,6 +276,20 @@ describe('Runner', () => {
                 validatorResults: [errorValidatorResult],
             });
         });
+
+        it('should init validators of test case ibefore its call to avoid their duplication in the next calls', async () => {
+            instance.initValidators.mockImplementation((): any =>
+                expect(instance.asyncCallbackHanlder).not.toHaveBeenCalled()
+            );
+
+            await instance.performTestAndReturnItsResult(
+                context,
+                testCase,
+                index
+            );
+
+            expect(instance.initValidators).toHaveBeenCalledWith(testCase);
+        });
     });
 
     describe('#asyncCallbackHanlder', () => {
@@ -320,6 +335,14 @@ describe('Runner', () => {
                 errorMessage: 'async test takes more than available 100ms',
             });
             expect(callback).toHaveBeenCalled();
+        });
+    });
+
+    describe('#initValidators', () => {
+        it('should set empty arary to validator of passed test case to avoi dduplications after each call', () => {
+            const testCase: any = { validators: [1, 2, 3] };
+            instance.initValidators(testCase);
+            expect(testCase.validators).toEqual([]);
         });
     });
 

--- a/packages/jasmine/tests/runner.test.ts
+++ b/packages/jasmine/tests/runner.test.ts
@@ -20,6 +20,7 @@ describe('Runner', () => {
 
     describe('#run', () => {
         const rootDescribersId = 'rootDescribersId';
+        const fDescribersId = 'fDescribersId';
         const performDescribersResult = 'performDescribersResult';
         const disabledDescriber = 'disabledDescriber';
         const disabledTestCase = 'disabledTestCase';
@@ -41,6 +42,17 @@ describe('Runner', () => {
             expect(testsResults).toBe(performDescribersResult);
             expect(instance.performDecribers).toHaveBeenCalledWith(
                 rootDescribersId,
+                []
+            );
+        });
+
+        it('should async return list of results only for chosen tests if they exist', async () => {
+            instance.store.fDescribersId = fDescribersId;
+            const { testsResults } = await instance.run();
+
+            expect(testsResults).toBe(performDescribersResult);
+            expect(instance.performDecribers).toHaveBeenCalledWith(
+                fDescribersId,
                 []
             );
         });


### PR DESCRIPTION
1. extend store to save chosen test cases
2. implement #fit method 
3. extend #run to support performance of chosen test cases
4. add integration tests for enabled/disabled/chosen test cases
5. fix issue related to duplication of validator results in each test case if #run is called multiple times (results of previous run was storied in each test case without their clean up based on mutable structure of their storage)