### PR TITLE
implement #fdescribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo demonstrates core concepts of modern/popular JS libraries
 
 -   express (core principies and imitation their communication on any request)
 -   jasmine/jest(test framefork functionality):
-    -   (x)describe
+    -   (x/f)describe
     -   beforeEach/afterEach
     -   (x/f)it
     -   expect

--- a/packages/jasmine/inner-describe.methods.ts
+++ b/packages/jasmine/inner-describe.methods.ts
@@ -2,8 +2,11 @@ import { InnerDescribeMethodsCore, Callback } from './models/jasmine.model';
 import { Describer, It } from './models/describe.model';
 import { Store } from './models/store.model';
 import uniqueId from 'lodash.uniqueid';
+import { GetDescriberIdWithPrefix, getDescriberIdWithPrefix } from './utils';
 
 export class InnerDescribeMethods implements InnerDescribeMethodsCore {
+    private getDescriberIdWithPrefix: GetDescriberIdWithPrefix = getDescriberIdWithPrefix;
+
     constructor(private store: Store) {}
 
     public fit = (description: string, callback: Callback): void => {
@@ -33,6 +36,12 @@ export class InnerDescribeMethods implements InnerDescribeMethodsCore {
 
     public it = (description: string, callback: Callback): void => {
         const describer = this.getActiveDescriber();
+
+        if (describer.isFDescribe) {
+            this.fit(description, callback);
+            return;
+        }
+
         describer.testCases = [
             ...describer.testCases,
             {
@@ -66,7 +75,9 @@ export class InnerDescribeMethods implements InnerDescribeMethodsCore {
 
     private registerFDescriber(fDescriber: Describer): void {
         const { store } = this;
-        const fDescriberId = uniqueId('fdescr-');
+        const fDescriberId = uniqueId(
+            this.getDescriberIdWithPrefix(fDescriber.isFDescribe, 'descr-')
+        );
 
         store.describers = {
             ...store.describers,

--- a/packages/jasmine/jasmine.ts
+++ b/packages/jasmine/jasmine.ts
@@ -24,6 +24,7 @@ export class Jasmine implements JasmineCore {
         inactiveTestCases: [],
     };
 
+    public fdescribe: DescribeModel;
     public describe: DescribeModel;
     public xdescribe: DescribeModel;
 
@@ -40,6 +41,7 @@ export class Jasmine implements JasmineCore {
 
     constructor() {
         const describeInstance = new Describe(this.store);
+        this.fdescribe = describeInstance.fdescribe;
         this.describe = describeInstance.describe;
         this.xdescribe = describeInstance.xdescribe;
 

--- a/packages/jasmine/models/describe.model.ts
+++ b/packages/jasmine/models/describe.model.ts
@@ -20,6 +20,7 @@ export interface Describer {
     childrenDescribersId: Array<string>;
     testCases: Array<TestCase>;
     context: Context;
+    isFDescribe: boolean;
 }
 
 export interface Describers {
@@ -35,4 +36,5 @@ export interface DescriberArguments {
     description: string;
     callback: Callback;
     parentMethods?: ParentMethods;
+    isFDescribe?: boolean;
 }

--- a/packages/jasmine/models/jasmine.model.ts
+++ b/packages/jasmine/models/jasmine.model.ts
@@ -6,6 +6,7 @@ export type CallbackList = Array<Callback>;
 
 export type DescribeModel = (description: string, callback: Callback) => void;
 export interface DescribeCore {
+    fdescribe: DescribeModel;
     describe: DescribeModel;
     xdescribe: DescribeModel;
 }

--- a/packages/jasmine/tests/describe.test.ts
+++ b/packages/jasmine/tests/describe.test.ts
@@ -12,6 +12,7 @@ describe('Describe', () => {
     const describerId = 'describerId';
     const activeDescriberId = 'activeDescriberId';
     const parentMethods = 'parentMethods';
+    const isFDescribe = 'isFDescribe';
 
     beforeEach(() => {
         instance = new Describe({ ...store });
@@ -20,6 +21,27 @@ describe('Describe', () => {
     beforeEach(() => {
         callback = jest.fn();
         describer = 'describer';
+    });
+
+    describe('#fdescribe', () => {
+        beforeEach(() => {
+            instance.describeHandler = jest.fn().mockName('describeHandler');
+            instance.getEmptyParentMethods = jest
+                .fn()
+                .mockName('getEmptyParentMethods')
+                .mockReturnValue(parentMethods);
+        });
+
+        it('should call #describeHandler with specific isFdescribe flag set to true', () => {
+            instance.fdescribe(description, callback);
+            expect(instance.getEmptyParentMethods).toHaveBeenCalled();
+            expect(instance.describeHandler).toHaveBeenCalledWith({
+                description,
+                callback,
+                parentMethods,
+                isFDescribe: true,
+            });
+        });
     });
 
     describe('#xdescribe', () => {
@@ -80,6 +102,7 @@ describe('Describe', () => {
             describerArguments = {
                 description,
                 callback,
+                isFDescribe,
             };
 
             instance.store.nextDescriberArguments = [
@@ -113,6 +136,7 @@ describe('Describe', () => {
                     description,
                     callback,
                     parentMethods,
+                    isFDescribe,
                 },
             ]);
             expect(instance.getEmptyParentMethods).toHaveBeenCalled();

--- a/packages/jasmine/tests/inner-describe.methods.test.ts
+++ b/packages/jasmine/tests/inner-describe.methods.test.ts
@@ -114,6 +114,7 @@ describe('InnerDescribeMethods', () => {
                 .fn()
                 .mockName('getActiveDescriber')
                 .mockReturnValue(describer);
+            instance.fit = jest.fn().mockName('fit');
         });
 
         it('should init new test cases with passed description and callback and empty validators to active describer', () => {
@@ -123,6 +124,15 @@ describe('InnerDescribeMethods', () => {
                 existedItStructure,
                 { it: { description, callback }, validators: [] },
             ]);
+        });
+
+        it('should register test case as fit if active describer if called from fdescribe', () => {
+            describer.isFDescribe = true;
+            instance.it(description, callback);
+            expect(instance.getActiveDescriber).toHaveBeenCalled();
+            expect(describer.testCases).toEqual([existedItStructure]);
+
+            expect(instance.fit).toHaveBeenCalledWith(description, callback);
         });
     });
 
@@ -168,11 +178,11 @@ describe('InnerDescribeMethods', () => {
             instance.registerFDescriber(describer);
             expect(instance.store.describers).toEqual({
                 existedDescribers: true,
-                'fdescr-1': describer,
+                'descr-1': describer,
             });
             expect(instance.store.fDescribersId).toEqual([
                 existedFDescriberId,
-                'fdescr-1',
+                'descr-1',
             ]);
         });
     });

--- a/packages/jasmine/tests/jasmine.access.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.access.integration.test.ts
@@ -1,0 +1,209 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Jasmine } from '../jasmine';
+
+const inst = new Jasmine();
+
+const fit1 = () => inst.expect(1).toBe(1);
+const fit2 = () => inst.expect(1).toBe(1);
+const it1 = () => inst.expect(1).toBe(1);
+const it2 = () => inst.expect(1).toBe(1);
+inst.describe('d1', () => {
+    inst.fit('fit1', fit1);
+});
+
+inst.fdescribe('fd1', () => {
+    inst.fit('fit2', fit2);
+
+    inst.it('it1', it1);
+
+    inst.describe('d2', () => {
+        inst.it('it2', it2);
+    });
+
+    inst.xdescribe('x2', () => {
+        inst.fit('fit3', () => {
+            inst.expect(1).toBe(1);
+        });
+    });
+});
+
+const getTestResults = async (
+    resultsPromise: any,
+    index: number
+): Promise<any> => {
+    const { testsResults } = await resultsPromise;
+    return testsResults[index];
+};
+
+describe('validate f/x/ access modificators to describe method', () => {
+    describe('validate formed structue with modificators methods', () => {
+        it('should return list of valid describersId', () => {
+            expect((inst as any).store.fDescribersId).toEqual([
+                'descr-2',
+                'fdescr-4',
+                'fdescr-5',
+            ]);
+
+            expect(Object.keys((inst as any).store.describers)).toEqual([
+                'root-1',
+                'descr-2',
+                'froot-3',
+                'fdescr-4',
+                'fdescr-5',
+                'child-6',
+            ]);
+        });
+
+        it('child-6: -> should return valid sctructure of the tests with modificators', () => {
+            expect((inst as any).store.describers['child-6']).toEqual({
+                afterEachList: [],
+                beforeEachList: [],
+                childrenDescribersId: [],
+                context: {},
+                description: 'd2',
+                isFDescribe: undefined,
+                testCases: [
+                    {
+                        it: { callback: it2, description: 'it2' },
+                        validators: [],
+                    },
+                ],
+            });
+        });
+
+        it('descr-2: -> should return valid sctructure of the tests with modificators', () => {
+            expect((inst as any).store.describers['descr-2']).toEqual({
+                afterEachList: [],
+                beforeEachList: [],
+                childrenDescribersId: [],
+                context: {},
+                description: 'd1',
+                isFDescribe: undefined,
+                testCases: [
+                    {
+                        it: { callback: fit1, description: 'fit1' },
+                        validators: [],
+                    },
+                ],
+            });
+        });
+
+        it('fdescr-4: -> should return valid sctructure of the tests with modificators', () => {
+            expect((inst as any).store.describers['fdescr-4']).toEqual({
+                afterEachList: [],
+                beforeEachList: [],
+                childrenDescribersId: [],
+                context: {},
+                description: 'fd1',
+                isFDescribe: true,
+                testCases: [
+                    {
+                        it: { callback: fit2, description: 'fit2' },
+                        validators: [],
+                    },
+                ],
+            });
+        });
+
+        it('fdescr-5: -> should return valid sctructure of the tests with modificators', () => {
+            expect((inst as any).store.describers['fdescr-5']).toEqual({
+                afterEachList: [],
+                beforeEachList: [],
+                childrenDescribersId: [],
+                context: {},
+                description: 'fd1',
+                isFDescribe: true,
+                testCases: [
+                    {
+                        it: { callback: it1, description: 'it1' },
+                        validators: [],
+                    },
+                ],
+            });
+        });
+
+        it('froot-3: -> should return valid sctructure of the tests with modificators', () => {
+            expect((inst as any).store.describers['froot-3']).toEqual({
+                afterEachList: [],
+                beforeEachList: [],
+                childrenDescribersId: ['child-6'],
+                context: {},
+                description: 'fd1',
+                isFDescribe: true,
+                testCases: [],
+            });
+        });
+
+        it('root-1: -> should return valid sctructure of the tests with modificators', () => {
+            expect((inst as any).store.describers['root-1']).toEqual({
+                afterEachList: [],
+                beforeEachList: [],
+                childrenDescribersId: [],
+                context: {},
+                description: 'd1',
+                isFDescribe: undefined,
+                testCases: [],
+            });
+        });
+    });
+
+    describe('validate tests results with modificators methods', () => {
+        it('should return valid list of disabled methods', async () => {
+            const { disabledMethods } = await inst.run();
+            expect(disabledMethods.describers).toEqual(['x2']);
+            expect(disabledMethods.testCases).toEqual([]);
+        });
+
+        it('should perform only tests placed in f if they exists', async () => {
+            const { testsResults } = await inst.run();
+            expect(testsResults.length).toBe(3);
+        });
+
+        it('d1: -> should return valid list of passed tests', async () => {
+            const results = await getTestResults(inst.run(), 0);
+            expect(results).toEqual({
+                description: 'd1',
+                testCaseResults: [
+                    {
+                        itDescription: 'fit1',
+                        validatorResults: [
+                            { errorMessage: '', isSuccess: true },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it('f1 fit2: -> should return valid list of passed tests', async () => {
+            const results = await getTestResults(inst.run(), 1);
+            expect(results).toEqual({
+                description: 'fd1',
+                testCaseResults: [
+                    {
+                        itDescription: 'fit2',
+                        validatorResults: [
+                            { errorMessage: '', isSuccess: true },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it('f1 it1: -> should return valid list of passed tests', async () => {
+            const results = await getTestResults(inst.run(), 2);
+            expect(results).toEqual({
+                description: 'fd1',
+                testCaseResults: [
+                    {
+                        itDescription: 'it1',
+                        validatorResults: [
+                            { errorMessage: '', isSuccess: true },
+                        ],
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/packages/jasmine/tests/jasmine.test.ts
+++ b/packages/jasmine/tests/jasmine.test.ts
@@ -10,6 +10,7 @@ describe('Jasmine', () => {
     });
 
     it('should define test API', () => {
+        expect(instance.fdescribe).toBeDefined();
         expect(instance.describe).toBeDefined();
         expect(instance.xdescribe).toBeDefined();
 

--- a/packages/jasmine/tests/jasmine.xf.integration.test.ts
+++ b/packages/jasmine/tests/jasmine.xf.integration.test.ts
@@ -127,8 +127,8 @@ describe('test of enabled/disabled/chosen test cases', () => {
         });
     });
 
-    it('fdescr-3: shold return valid structure', () => {
-        expect(getDescriberById(instance, 'fdescr-3')).toEqual({
+    it('descr-3: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'descr-3')).toEqual({
             afterEachList: [],
             beforeEachList: [cb4],
             childrenDescribersId: [],
@@ -146,8 +146,8 @@ describe('test of enabled/disabled/chosen test cases', () => {
         });
     });
 
-    it('fdescr-4: shold return valid structure', () => {
-        expect(getDescriberById(instance, 'fdescr-4')).toEqual({
+    it('descr-4: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'descr-4')).toEqual({
             afterEachList: [],
             beforeEachList: [cb4],
             childrenDescribersId: [],
@@ -165,8 +165,8 @@ describe('test of enabled/disabled/chosen test cases', () => {
         });
     });
 
-    it('fdescr-6: shold return valid structure', () => {
-        expect(getDescriberById(instance, 'fdescr-6')).toEqual({
+    it('descr-6: shold return valid structure', () => {
+        expect(getDescriberById(instance, 'descr-6')).toEqual({
             afterEachList: [],
             beforeEachList: [cb4, cb7],
             childrenDescribersId: [],
@@ -195,9 +195,9 @@ describe('test for forming root describer/fdescriber Ids', () => {
 
     it('should form valid list of rootFDescribersId', () => {
         expect((instance as any).store.fDescribersId).toEqual([
-            'fdescr-3',
-            'fdescr-4',
-            'fdescr-6',
+            'descr-3',
+            'descr-4',
+            'descr-6',
         ]);
     });
 });

--- a/packages/jasmine/tests/utils.test.ts
+++ b/packages/jasmine/tests/utils.test.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { isSpy } from '../utils';
+import {
+    isSpy,
+    stringifyPassedValue,
+    getDescriberIdWithPrefix,
+} from '../utils';
 
 describe('#isSpy', () => {
     it('should return true if passed actual result is spy', () => {
@@ -13,5 +17,30 @@ describe('#isSpy', () => {
         const notSpy: any = () => true;
         expect(isSpy(notSpy)).toBeFalsy();
         expect(isSpy(undefined)).toBeFalsy();
+    });
+});
+
+describe('#stringifyPassedValue', () => {
+    it('should return string with function name if function passed', () => {
+        const spy: any = () => true;
+        expect(stringifyPassedValue(spy)).toBe('function with name: spy');
+    });
+
+    it('should return stringified value for other cases', () => {
+        expect(stringifyPassedValue({ a: 1, b: ['str'] })).toBe(
+            '{"a":1,"b":["str"]}'
+        );
+    });
+});
+
+describe('#getDescriberIdWithPrefix', () => {
+    const prefix = 'prefix';
+
+    it('should prefix as it is for not fdescribe', () => {
+        expect(getDescriberIdWithPrefix(false, prefix)).toBe(prefix);
+    });
+
+    it('should modified prefix for  fdescribe', () => {
+        expect(getDescriberIdWithPrefix(true, prefix)).toBe(`f${prefix}`);
     });
 });

--- a/packages/jasmine/utils.ts
+++ b/packages/jasmine/utils.ts
@@ -14,3 +14,12 @@ export const stringifyPassedValue = (passedValue: any): string =>
     isFunction(passedValue)
         ? `function with name: ${passedValue.name}`
         : JSON.stringify(passedValue);
+
+export type GetDescriberIdWithPrefix = (
+    isFDescribe: boolean,
+    prefix: string
+) => string;
+export const getDescriberIdWithPrefix = (
+    isFDescribe: boolean,
+    prefix: string
+): string => (isFDescribe ? `f${prefix}` : prefix);


### PR DESCRIPTION
1. implement #fdescribe 
- if fdescribe called -> only its tests and `fit` will be called
- each test case it/fit will be called in #fdescribe 
- nested #describe will not be called, till they will not contain any `fit` or will be transformed to `fdecribe`
 - xit/xdescribe -> always ignored all placed in them (including nested (f)describers) 
2. integrate fdescribe logic with `it` -> some `it` called in the `fdescribe` will be called as `fit`
3. update ids for describers
 -root / froot -> for root describers
 -child / fchild -> for nested describers
 -desc / fdescr -> for describers formed from `fit`
4. add integration tests for access modifiers
5. actualize readme