### PR TITLE
fix incorrect passed type of arguments in test

### DIFF
--- a/packages/jasmine/tests/spy.test.ts
+++ b/packages/jasmine/tests/spy.test.ts
@@ -193,10 +193,8 @@ describe('Spy', () => {
             });
 
             it('should  return result of spy handler function', () => {
-                const handlerResult = 'handlerResult';
-                handler.mockReturnValue(handlerResult);
-                expect(instance.perfromSpyCall(spyMethod, ...args)).toBe(
-                    handlerResult
+                expect(instance.perfromSpyCall(spyMethod, args)).toBe(
+                    spyResult
                 );
             });
         });


### PR DESCRIPTION
once bundle is built the test is failed since it expects to be called like `handler.apply(context, arrayOfArguments)` and in the test it is called like `handler.apply(context, argument1, argument2, etc)` 


The issue is in the test only