### PR TITLE
Redux subscriber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,6 +1395,15 @@
             "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==",
             "dev": true
         },
+        "@types/lodash.get": {
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
+            "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
+            "dev": true,
+            "requires": {
+                "@types/lodash": "*"
+            }
+        },
         "@types/lodash.isequal": {
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
@@ -4151,6 +4160,12 @@
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
         "lodash.isequal": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@babel/preset-env": "^7.9.5",
         "@babel/preset-typescript": "^7.9.0",
         "@types/jest": "^25.2.1",
+        "@types/lodash.get": "^4.4.6",
         "@types/lodash.isequal": "^4.5.5",
         "@types/lodash.isfunction": "^3.0.6",
         "@types/lodash.uniqueid": "^4.0.6",
@@ -39,6 +40,7 @@
     "dependencies": {
         "lodash.isequal": "^4.5.0",
         "lodash.isfunction": "^3.0.9",
-        "lodash.uniqueid": "^4.0.1"
+        "lodash.uniqueid": "^4.0.1",
+        "lodash.get": "^4.4.2"
     }
 }

--- a/packages/redux-subscriber/redux-subscriber.model.ts
+++ b/packages/redux-subscriber/redux-subscriber.model.ts
@@ -5,11 +5,36 @@ import {
     BaseAction,
 } from '../redux/redux.model';
 
+export enum ListenerTypes {
+    customListener = 'customListener',
+    actionListener = 'actionListener',
+}
+
+export interface CustomListenerData<Listener> {
+    listener: Listener;
+    pathToListenValue: string;
+    listenerType: ListenerTypes;
+}
+
+export interface ActionListenerData<Listener> {
+    listener: Listener;
+    actionsToFire: Array<string>;
+    listenerType: ListenerTypes;
+}
+
+export type CommonListenerData<T> =
+    | CustomListenerData<T>
+    | ActionListenerData<T>;
+export type ListenersDataStore<T> = Array<CommonListenerData<T>>;
+
 export interface ReduxSubscriber<State, Action extends BaseAction>
     extends ReduxStore<State, Action> {
     setCustomListener(
         pathToListenValue: string,
-        listener: Subscriber<State>,
-        actionsToFire: Array<string>
+        listener: Subscriber<State>
+    ): Unsubscriber;
+    setActionListener(
+        actionsToFire: Array<string>,
+        listener: Subscriber<State>
     ): Unsubscriber;
 }

--- a/packages/redux-subscriber/redux-subscriber.model.ts
+++ b/packages/redux-subscriber/redux-subscriber.model.ts
@@ -1,0 +1,15 @@
+import {
+    ReduxStore,
+    Unsubscriber,
+    Subscriber,
+    BaseAction,
+} from '../redux/redux.model';
+
+export interface ReduxSubscriber<State, Action extends BaseAction>
+    extends ReduxStore<State, Action> {
+    setCustomListener(
+        pathToListenValue: string,
+        listener: Subscriber<State>,
+        actionsToFire: Array<string>
+    ): Unsubscriber;
+}

--- a/packages/redux-subscriber/redux-subscriber.ts
+++ b/packages/redux-subscriber/redux-subscriber.ts
@@ -1,0 +1,143 @@
+import get from 'lodash.get';
+
+import { ReduxSubscriber } from './redux-subscriber.model';
+import {
+    ReduxStore,
+    Unsubscriber,
+    Subscriber,
+    BaseAction,
+} from '../redux/redux.model';
+
+export interface ListenerData<Listener> {
+    listener: Listener;
+    actionsToFire: Array<string>;
+}
+
+interface ListenersDataStore<Listener> {
+    [pathToListenValue: string]: Array<ListenerData<Listener>>;
+}
+
+class SubscriberStore<State, Action extends BaseAction>
+    implements ReduxSubscriber<State, Action> {
+    private listenersDataStore: ListenersDataStore<Subscriber<State>> = {};
+    private customListenerUnsubscriber: Unsubscriber;
+    private firedAction: string;
+
+    constructor(private store: ReduxStore<State, Action>) {
+        this.activateCustomListenersSubscriber();
+    }
+
+    getState(): State {
+        return this.store.getState();
+    }
+    subscribe(cb: Subscriber<State>): Unsubscriber {
+        return this.store.subscribe(cb);
+    }
+    dispatch(action: Action): void {
+        this.firedAction = action.type;
+        this.store.dispatch(action);
+    }
+    unsubscribeCustomListenerSubscriber(): void {
+        this.customListenerUnsubscriber();
+    }
+    setCustomListener(
+        pathToListenValue: string,
+        listener: Subscriber<State>,
+        actionsToFire: string[] = []
+    ): Unsubscriber {
+        this.setListenerDataToStore(pathToListenValue, listener, actionsToFire);
+        return (): void => this.unsubscribe(pathToListenValue, listener);
+    }
+
+    private setListenerDataToStore(
+        pathToListenValue: string,
+        listener: Subscriber<State>,
+        actionsToFire: string[]
+    ): void {
+        const listenersData = this.listenersDataStore[pathToListenValue];
+        const listenerData: ListenerData<Subscriber<State>> = {
+            actionsToFire,
+            listener,
+        };
+
+        this.listenersDataStore[pathToListenValue] = [
+            ...listenersData,
+            listenerData,
+        ];
+    }
+
+    private unsubscribe(
+        pathToListenValue: string,
+        listenerToUnsubscribe: Subscriber<State>
+    ): void {
+        this.listenersDataStore[pathToListenValue] = this.listenersDataStore[
+            pathToListenValue
+        ].filter(
+            ({ listener }: ListenerData<Subscriber<State>>) =>
+                listener !== listenerToUnsubscribe
+        );
+    }
+
+    private activateCustomListenersSubscriber(): void {
+        this.customListenerUnsubscriber = this.store.subscribe(
+            this.fireCustomListeners
+        );
+    }
+
+    private fireCustomListeners: Subscriber<State> = (
+        newState: State
+    ): void => {
+        const firedAction = this.firedAction;
+        this.firedAction = null;
+
+        const state = this.getState();
+        Object.keys(this.listenersDataStore)
+            .filter(this.isStateChangedInPath.bind(null, state, newState))
+            .forEach(
+                this.fireCustomListenersForChangedPath.bind(
+                    this,
+                    newState,
+                    firedAction
+                )
+            );
+    };
+
+    private isStateChangedInPath(
+        state: State,
+        newState: State,
+        pathToListenValue: string
+    ): boolean {
+        return (
+            get(state, pathToListenValue) !== get(newState, pathToListenValue)
+        );
+    }
+
+    private fireCustomListenersForChangedPath(
+        state: State,
+        firedAction: string,
+        pathToListenValue: string
+    ): void {
+        this.listenersDataStore[pathToListenValue]
+            .filter(this.sholdFireListener.bind(null, firedAction))
+            .forEach(this.fireListener.bind(null, state));
+    }
+
+    private sholdFireListener(
+        firedAction: string,
+        { actionsToFire }: ListenerData<Subscriber<State>>
+    ): boolean {
+        const shouldBeFiredAlways = !actionsToFire.length;
+        return shouldBeFiredAlways || actionsToFire.includes(firedAction);
+    }
+
+    private fireListener(
+        state: State,
+        { listener }: ListenerData<Subscriber<State>>
+    ): void {
+        listener(state);
+    }
+}
+
+export const getStoreWithSubscribers = <State, Action extends BaseAction>(
+    store: ReduxStore<State, Action>
+): ReduxSubscriber<State, Action> => new SubscriberStore<State, Action>(store);

--- a/packages/redux/redux.constant.ts
+++ b/packages/redux/redux.constant.ts
@@ -1,5 +1,5 @@
-import { BaseAction, INIT_STATE } from './redux.model';
+import { InitialAction, INIT_STATE } from './redux.model';
 
-export const baseAction: BaseAction = {
+export const initialAction: InitialAction = {
     type: INIT_STATE,
 };

--- a/packages/redux/redux.integration.test.ts
+++ b/packages/redux/redux.integration.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createStore } from './redux';
-import { BaseAction, Reducer, ReduxStore } from './redux.model';
+import { InitialAction, Reducer, ReduxStore } from './redux.model';
 
 interface State {
     index: number;
@@ -40,7 +40,7 @@ const setValueTo = (value: number): SetValueTo => ({
 
 const reducer: Reducer<State, Actions> = (
     state: State = initialState,
-    action: Actions | BaseAction
+    action: Actions | InitialAction
 ): State => {
     switch (action.type) {
         case INCREMENT_INDEX: {
@@ -63,7 +63,7 @@ const reducer: Reducer<State, Actions> = (
 };
 
 describe('integration tests', () => {
-    let store: ReduxStore<State, Actions, (state: State) => void>;
+    let store: ReduxStore<State, Actions>;
     let subscriber1: any;
     let subscriber2: any;
 

--- a/packages/redux/redux.model.ts
+++ b/packages/redux/redux.model.ts
@@ -1,16 +1,22 @@
-export const INIT_STATE = 'INIT_STATE';
-export type BaseAction = {
-    type: typeof INIT_STATE;
-};
+export interface BaseAction {
+    type: string;
+}
 
-export type Reducer<State, Action> = (
+export const INIT_STATE = 'INIT_STATE';
+export interface InitialAction {
+    type: typeof INIT_STATE;
+}
+
+export type Reducer<State, Action extends BaseAction> = (
     state: State,
-    action: Action | BaseAction
+    action: Action | InitialAction
 ) => State;
 export type Unsubscriber = () => void;
 
-export interface ReduxStore<State, Action, Callback extends Function> {
+export type Subscriber<State> = (state: State) => void;
+
+export interface ReduxStore<State, Action extends BaseAction> {
     getState(): State;
-    subscribe(cb: Callback): Unsubscriber;
-    dispatch(action: Action | BaseAction): void;
+    subscribe(cb: Subscriber<State>): Unsubscriber;
+    dispatch(action: Action | InitialAction): void;
 }

--- a/packages/redux/redux.test.ts
+++ b/packages/redux/redux.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { createStore } from './redux';
-import { baseAction } from './redux.constant';
+import { initialAction } from './redux.constant';
 
 describe('Redux', () => {
     let store: any;
@@ -26,7 +26,7 @@ describe('Redux', () => {
 
     it('should set state on init as the result of call the passed reducer', () => {
         expect(store.state).toBe(initialState);
-        expect(reducer).toHaveBeenCalledWith(undefined, baseAction);
+        expect(reducer).toHaveBeenCalledWith(undefined, initialAction);
     });
 
     describe('#getState', () => {


### PR DESCRIPTION
1. refactor redux Callback/Action types to define to their generics base functionality
2. implement redux-subscriber to be able call listeners only for required condition:
 - setCustomListener -> to call only if the field in the pointed path is changed
 - setActionListener -> to call only after dispatch of described actionTypes 